### PR TITLE
[QOL-8025] migrate PROD and STAGING to m6g instances

### DIFF
--- a/vars/database.var.yml
+++ b/vars/database.var.yml
@@ -31,7 +31,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "600"
-      DBClass: db.m5.large
+      DBClass: db.m6g.large
       StorageEncrypted: "True"
       PreferredMaintenanceWindow: "sat:17:00-sat:17:30"
       Environment: PROD
@@ -45,7 +45,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: '300'
-      DBClass: db.t3.large
+      DBClass: db.m6g.large
       StorageEncrypted: "True"
       Environment: STAGING
       MultiAZ: "true"


### PR DESCRIPTION
- STAGING gets a miniscule cost reduction but is no longer reliant on burst credits.
- PROD gets a slightly larger cost reduction and should get a performance boost.