### PR TITLE
[QOL-8060] don't make the secondary Solr instance auto-scale

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -142,28 +142,6 @@ Resources:
     Condition: 2PlusWebInstances
     Type: AWS::OpsWorks::Instance
     Properties:
-{% if item.tags["PowerManaged"] == "Yes" %}
-      AutoScalingType: timer
-      # Monday-Friday 06:00-20:00 GMT+10
-      TimeBasedAutoScaling:
-        Sunday:
-{% for hour in range(20, 24) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% for day in ["Monday","Tuesday","Wednesday","Thursday"] %}
-        {{ day }}:
-{% for hour in range(0, 10) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% for hour in range(20, 24) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% endfor %}
-        Friday:
-{% for hour in range(0, 10) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% endif %}
       Hostname: !Sub "${ApplicationId}-solr2"
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true


### PR DESCRIPTION
We want to control it manually during deployments.