### PR TITLE
Develop to master

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -142,28 +142,6 @@ Resources:
     Condition: 2PlusWebInstances
     Type: AWS::OpsWorks::Instance
     Properties:
-{% if item.tags["PowerManaged"] == "Yes" %}
-      AutoScalingType: timer
-      # Monday-Friday 06:00-20:00 GMT+10
-      TimeBasedAutoScaling:
-        Sunday:
-{% for hour in range(20, 24) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% for day in ["Monday","Tuesday","Wednesday","Thursday"] %}
-        {{ day }}:
-{% for hour in range(0, 10) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% for hour in range(20, 24) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% endfor %}
-        Friday:
-{% for hour in range(0, 10) %}
-          "{{ hour }}": "on"
-{% endfor %}
-{% endif %}
       Hostname: !Sub "${ApplicationId}-solr2"
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr7: "http://archive.apache.org/dist/lucene/solr/7.7.2/solr-7.7.2.zip"
-ckan_tag: "ckan-2.8.8-qgov.3"
+ckan_tag: "ckan-2.8.8-qgov.4"
 ckan_qgov_branch: "qgov-master-2.8.8"
 
 common_stack: &common_stack


### PR DESCRIPTION
The secondary Solr instance is meant to be manually controlled during deployments, so it shouldn't auto-scale.