### PR TITLE
[DC-22275] add memory thresholds to auto-scaling

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
@@ -506,11 +506,13 @@ Resources:
         Enable: Yes
         UpScaling:
           CpuThreshold: 80
+          MemoryThreshold: 80
           IgnoreMetricsTime: 20
           InstanceCount: 1
           ThresholdsWaitTime: 5
         DownScaling:
           CpuThreshold: 30
+          MemoryThreshold: 30
           IgnoreMetricsTime: 20
           InstanceCount: 1
           ThresholdsWaitTime: 10


### PR DESCRIPTION
- scale up for high memory utilisation, not just high CPU, since memory is more often our bottleneck