### PR TITLE
[QOL-8595] update ckanext-qgov to take over shared functions from ckanext-data-qld

### DIFF
--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -39,7 +39,7 @@ echo "Creating ${TEST_ORG_TITLE} Organisation:"
 
 TEST_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "'${TEST_ORG_NAME}'", "title": "'${TEST_ORG_TITLE}'"}' \
+    --data '{"name": "'"${TEST_ORG_NAME}"'", "title": "'"${TEST_ORG_TITLE}"'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -48,15 +48,15 @@ TEST_ORG_ID=$(echo $TEST_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${TEST_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_admin", "object_type": "user", "capacity": "admin"}' \
+    --data '{"id": "'"${TEST_ORG_ID}"'", "object": "test_org_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_editor", "object_type": "user", "capacity": "editor"}' \
+    --data '{"id": "'"${TEST_ORG_ID}"'", "object": "test_org_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_member", "object_type": "user", "capacity": "member"}' \
+    --data '{"id": "'"${TEST_ORG_ID}"'", "object": "test_org_member", "object_type": "user", "capacity": "member"}' \
     ${CKAN_ACTION_URL}/member_create
 ##
 # END.
@@ -75,7 +75,7 @@ echo "Assigning test Datasets to Organisation..."
 echo "Updating annakarenina to use ${TEST_ORG_TITLE} organisation:"
 package_owner_org_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "annakarenina", "organization_id": "'${TEST_ORG_NAME}'"}' \
+    --data '{"id": "annakarenina", "organization_id": "'"${TEST_ORG_NAME}"'"}' \
     ${CKAN_ACTION_URL}/package_owner_org_update
 )
 echo ${package_owner_org_update}
@@ -83,7 +83,7 @@ echo ${package_owner_org_update}
 echo "Updating warandpeace to use ${TEST_ORG_TITLE} organisation:"
 package_owner_org_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "warandpeace", "organization_id": "'${TEST_ORG_NAME}'"}' \
+    --data '{"id": "warandpeace", "organization_id": "'"${TEST_ORG_NAME}"'"}' \
     ${CKAN_ACTION_URL}/package_owner_org_update
 )
 echo ${package_owner_org_update}
@@ -105,7 +105,7 @@ echo "Creating ${DR_ORG_TITLE} Organisation:"
 
 DR_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '"name": "'${DR_ORG_NAME}'", "title": "'${DR_ORG_TITLE}'"}' \
+    --data '"name": "'"${DR_ORG_NAME}"'", "title": "'"${DR_ORG_TITLE}"'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -114,22 +114,22 @@ DR_ORG_ID=$(echo $DR_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${DR_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_admin", "object_type": "user", "capacity": "admin"}' \
+    --data '{"id": "'"${DR_ORG_ID}"'", "object": "dr_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_editor", "object_type": "user", "capacity": "editor"}' \
+    --data '{"id": "'"${DR_ORG_ID}"'", "object": "dr_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_member", "object_type": "user", "capacity": "member"}' \
+    --data '{"id": "'"${DR_ORG_ID}"'", "object": "dr_member", "object_type": "user", "capacity": "member"}' \
     ${CKAN_ACTION_URL}/member_create
 
 
 echo "Creating test Data Request:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"title": "Test Request", "description": "This is an example", "organization_id": "'${TEST_ORG_ID}'"}' \
+    --data '{"title": "Test Request", "description": "This is an example", "organization_id": "'"${TEST_ORG_ID}"'"}' \
     ${CKAN_ACTION_URL}/create_datarequest
 
 REPORT_ORG_NAME=reporting
@@ -144,7 +144,7 @@ echo "Creating ${REPORT_ORG_TITLE} Organisation:"
 
 REPORT_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "'${REPORT_ORG_NAME}'", "title": "'${REPORT_ORG_TITLE}'"}' \
+    --data '{"name": "'"${REPORT_ORG_NAME}"'", "title": "'"${REPORT_ORG_TITLE}"'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -153,17 +153,17 @@ REPORT_ORG_ID=$(echo $REPORT_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${REPORT_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${REPORT_ORG_ID}'", "object": "report_admin", "object_type": "user", "capacity": "admin"}' \
+    --data '{"id": "'"${REPORT_ORG_ID}"'", "object": "report_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'${REPORT_ORG_ID}'", "object": "report_editor", "object_type": "user", "capacity": "editor"}' \
+    --data '{"id": "'"${REPORT_ORG_ID}"'", "object": "report_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 echo "Creating test dataset for reporting:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "reporting", "description": "Dataset for reporting", "owner_org": "'${REPORT_ORG_ID}'", \
+    --data '{"name": "reporting", "description": "Dataset for reporting", "owner_org": "'"${REPORT_ORG_ID}"'", \
 "update_frequency": "near-realtime", "author_email": "report_admin@localhost", "version": "1.0", "license_id": "cc-by-4",\
 "data_driven_application": "NO", "security_classification": "PUBLIC", "notes": "test", "de_identified_data": "NO"}'\
     ${CKAN_ACTION_URL}/package_create
@@ -171,7 +171,7 @@ curl -LsH "Authorization: ${API_KEY}" \
 echo "Creating test Data Request for reporting:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"title": "Reporting Request", "description": "Data Request for reporting", "organization_id": "'${REPORT_ORG_ID}'"}' \
+    --data '{"title": "Reporting Request", "description": "Data Request for reporting", "organization_id": "'"${REPORT_ORG_ID}"'"}' \
     ${CKAN_ACTION_URL}/create_datarequest
 
 

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -38,7 +38,7 @@ echo "Creating ${TEST_ORG_TITLE} Organisation:"
 
 TEST_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=${TEST_ORG_NAME}&title=${TEST_ORG_TITLE}" \
+    --data '{"name": "'${TEST_ORG_NAME}'", "title": "'${TEST_ORG_TITLE}'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -47,15 +47,15 @@ TEST_ORG_ID=$(echo $TEST_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${TEST_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${TEST_ORG_ID}&object=test_org_admin&object_type=user&capacity=admin" \
+    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${TEST_ORG_ID}&object=test_org_editor&object_type=user&capacity=editor" \
+    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${TEST_ORG_ID}&object=test_org_member&object_type=user&capacity=member" \
+    --data '{"id": "'${TEST_ORG_ID}'", "object": "test_org_member", "object_type": "user", "capacity": "member"}' \
     ${CKAN_ACTION_URL}/member_create
 ##
 # END.
@@ -74,7 +74,7 @@ echo "Assigning test Datasets to Organisation..."
 echo "Updating annakarenina to use ${TEST_ORG_TITLE} organisation:"
 package_owner_org_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=annakarenina&organization_id=${TEST_ORG_NAME}" \
+    --data '{"id": "annakarenina", "organization_id": "'${TEST_ORG_NAME}'"}' \
     ${CKAN_ACTION_URL}/package_owner_org_update
 )
 echo ${package_owner_org_update}
@@ -82,7 +82,7 @@ echo ${package_owner_org_update}
 echo "Updating warandpeace to use ${TEST_ORG_TITLE} organisation:"
 package_owner_org_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=warandpeace&organization_id=${TEST_ORG_NAME}" \
+    --data '{"id": "warandpeace", "organization_id": "'${TEST_ORG_NAME}'"}' \
     ${CKAN_ACTION_URL}/package_owner_org_update
 )
 echo ${package_owner_org_update}
@@ -104,7 +104,7 @@ echo "Creating ${DR_ORG_TITLE} Organisation:"
 
 DR_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=${DR_ORG_NAME}&title=${DR_ORG_TITLE}" \
+    --data '"name": "'${DR_ORG_NAME}'", "title": "'${DR_ORG_TITLE}'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -113,22 +113,22 @@ DR_ORG_ID=$(echo $DR_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${DR_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_admin&object_type=user&capacity=admin" \
+    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_editor&object_type=user&capacity=editor" \
+    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_member&object_type=user&capacity=member" \
+    --data '{"id": "'${DR_ORG_ID}'", "object": "dr_member", "object_type": "user", "capacity": "member"}' \
     ${CKAN_ACTION_URL}/member_create
 
 
 echo "Creating test Data Request:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "title=Test Request&description=This is an example&organization_id=${TEST_ORG_ID}" \
+    --data '{"title": "Test Request", "description": "This is an example", "organization_id": "'${TEST_ORG_ID}'"}' \
     ${CKAN_ACTION_URL}/create_datarequest
 
 REPORT_ORG_NAME=reporting
@@ -143,7 +143,7 @@ echo "Creating ${REPORT_ORG_TITLE} Organisation:"
 
 REPORT_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=${REPORT_ORG_NAME}&title=${REPORT_ORG_TITLE}" \
+    --data '{"name": "'${REPORT_ORG_NAME}'", "title": "'${REPORT_ORG_TITLE}'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -152,25 +152,25 @@ REPORT_ORG_ID=$(echo $REPORT_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
 echo "Assigning test users to ${REPORT_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${REPORT_ORG_ID}&object=report_admin&object_type=user&capacity=admin" \
+    --data '{"id": "'${REPORT_ORG_ID}'", "object": "report_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${REPORT_ORG_ID}&object=report_editor&object_type=user&capacity=editor" \
+    --data '{"id": "'${REPORT_ORG_ID}'", "object": "report_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
 echo "Creating test dataset for reporting:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=reporting&description=Dataset for reporting&owner_org=${REPORT_ORG_ID}&\
-update_frequency=near-realtime&author_email=report_admin@localhost&version=1.0&license_id=cc-by-4\
-&data_driven_application=NO&security_classification=PUBLIC&notes=test&de_identified_data=NO"\
+    --data '{"name": "reporting", "description": "Dataset for reporting", "owner_org": "'${REPORT_ORG_ID}'", \
+"update_frequency": "near-realtime", "author_email": "report_admin@localhost", "version": "1.0", "license_id": "cc-by-4",\
+"data_driven_application": "NO", "security_classification": "PUBLIC", "notes": "test", "de_identified_data": "NO"}'\
     ${CKAN_ACTION_URL}/package_create
 
 echo "Creating test Data Request for reporting:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data "title=Reporting Request&description=Data Request for reporting&organization_id=${REPORT_ORG_ID}" \
+    --data '{"title": "Reporting Request", "description": "Data Request for reporting", "organization_id": "'${REPORT_ORG_ID}'"}' \
     ${CKAN_ACTION_URL}/create_datarequest
 
 

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -163,8 +163,8 @@ curl -LsH "Authorization: ${API_KEY}" \
 echo "Creating test dataset for reporting:"
 
 curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "reporting", "description": "Dataset for reporting", "owner_org": "'"${REPORT_ORG_ID}"'", \
-"update_frequency": "near-realtime", "author_email": "report_admin@localhost", "version": "1.0", "license_id": "cc-by-4",\
+    --data '{"name": "reporting", "description": "Dataset for reporting", "owner_org": "'"${REPORT_ORG_ID}"'",
+"update_frequency": "near-realtime", "author_email": "report_admin@localhost", "version": "1.0", "license_id": "cc-by-4",
 "data_driven_application": "NO", "security_classification": "PUBLIC", "notes": "test", "de_identified_data": "NO"}'\
     ${CKAN_ACTION_URL}/package_create
 

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -65,7 +65,7 @@ curl -LsH "Authorization: ${API_KEY}" \
 ckan_cli create-test-data hierarchy
 
 # Creating basic test data which has datasets with resources
-ckan_cli create-test-data
+ckan_cli create-test-data basic
 
 # Datasets need to be assigned to an organisation
 

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -105,7 +105,7 @@ echo "Creating ${DR_ORG_TITLE} Organisation:"
 
 DR_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '"name": "'"${DR_ORG_NAME}"'", "title": "'"${DR_ORG_TITLE}"'"}' \
+    --data '{"name": "'"${DR_ORG_NAME}"'", "title": "'"${DR_ORG_TITLE}"'"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -3,6 +3,7 @@
 # Create some example content for extension BDD tests.
 #
 set -e
+set -x
 
 CKAN_ACTION_URL=http://ckan:3000/api/action
 

--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -95,7 +95,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view datastore data_qld_theme datarequests data_qld_resources data_qld_integration scheming_datasets validation dcat qa archiver report qgovext data_qld_reporting data_qld_googleanalytics ytp_comments
+ckan.plugins = stats text_view image_view recline_view datastore data_qld_theme datarequests data_qld_resources data_qld_integration scheming_datasets validation dcat qa archiver report qgovext data_qld_reporting data_qld_google_analytics ytp_comments
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -95,7 +95,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view datastore data_qld_theme datarequests data_qld_resources data_qld_integration scheming_datasets validation dcat qa archiver report qgovext data_qld_reporting ytp_comments
+ckan.plugins = stats text_view image_view recline_view datastore data_qld_theme datarequests data_qld_resources data_qld_integration scheming_datasets validation dcat qa archiver report qgovext data_qld_reporting data_qld_googleanalytics ytp_comments
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.docker/test-Publications.ini
+++ b/.docker/test-Publications.ini
@@ -95,7 +95,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view data_qld_resources publications_qld_theme qgovext
+ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Retrieve screenshots
         if: failure()
         run: .circleci/process-artifacts.sh
-        timeout-minutes: 3
+        timeout-minutes: 1
 
       - name: Upload screenshots
         if: failure()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,6 @@ x-environment:
   AMAZEEIO: AMAZEEIO
   no_proxy: "ckan,postgres,postgres-datastore,redis,solr,chrome,mailhog.docker.amazee.io"
 
-x-user:
-  &default-user
-  # The default user under which the containers should run.
-  # Change this if you are on linux and run with another user than id `1000`.
-  user: '1000'
-
 services:
 
   ckan:

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -2,22 +2,23 @@
 Feature: Login Redirection
 
     @dashboard_login
-    Scenario: As an unauthenticated user, when I visit the /dashboard URL I see the login page
-        Given "Unauthenticated" as the persona
-        When I visit "/dashboard"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+    Scenario Outline: As an unauthenticated user, when I visit the dashboard URL I see the login page
+        Given "TestOrgMember" as the persona
+        When I visit "<URL>"
+        Then I should see a login link
+        When I log in directly
+        Then I should see "News feed"
 
-    @dashboard_login
-    Scenario: As an unauthenticated user, when I visit the /dashboard/ URL I see the login page
-        Given "Unauthenticated" as the persona
-        When I visit "/dashboard/"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+        Examples: Dashboard URLs
+        | URL              |
+        | /dashboard       |
+        | /dashboard/      |
 
     @user_edit
-    Scenario: As an unauthenticated organisation member, when I visit the /user/edit URL I see the login page. Upon logging in I am taken to the /user/edit page
+    Scenario: As an unauthenticated organisation member, when I visit the user edit URL I see the login page. Upon logging in I am taken to the user edit page
         Given "TestOrgMember" as the persona
         When I visit "/user/edit"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+        Then I should see a login link
         When I log in directly
         Then I should see "Change details"
 
@@ -36,7 +37,7 @@ Feature: Login Redirection
     Scenario: As an unauthenticated user, when I visit the URL of a private dataset I see the login page
         Given "Unauthenticated" as the persona
         When I visit "/dataset/annakarenina"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+        Then I should see a login link
 
     @public_dataset
     Scenario: As an unauthenticated user, when I visit the URL of a public dataset I see the dataset without needing to login
@@ -50,7 +51,7 @@ Feature: Login Redirection
     Scenario: As an unauthenticated organisation member, when I visit the URL of a private dataset I see the login page. Upon logging in I am taken to the private dataset
         Given "TestOrgMember" as the persona
         When I visit "/dataset/annakarenina"
-        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+        Then I should see a login link
         When I log in directly
         Then I should see an element with xpath "//h1[contains(string(), 'A Novel By Tolstoy')]"
         And I should see an element with xpath "//span[contains(string(), 'Private')]"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -12,12 +12,17 @@ def get_current_url(context):
     context.browser.evaluate_script("document.documentElement.clientWidth")
 
 
-@step('I go to homepage')
+@step(u'I go to homepage')
 def go_to_home(context):
     when_i_visit_url(context, '/')
 
 
-@step('I log in')
+@step(u'I go to register page')
+def go_to_register_page(context):
+    when_i_visit_url(context, '/user/register')
+
+
+@step(u'I log in')
 def log_in(context):
     assert context.persona
     context.execute_steps(u"""
@@ -27,7 +32,7 @@ def log_in(context):
     """)
 
 
-@step('I log in directly')
+@step(u'I log in directly')
 def log_in_directly(context):
     """
     This differs to the `log_in` function above by logging in directly to a page where the user login form is presented
@@ -44,6 +49,13 @@ def log_in_directly(context):
     """)
 
 
+@step(u'I should see a login link')
+def login_link_visible(context):
+    context.execute_steps(u"""
+        Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
+    """)
+
+
 @step('I fill in title with random text')
 def title_random_text(context):
 
@@ -53,17 +65,27 @@ def title_random_text(context):
     """.format(random.randrange(1000)))
 
 
-@step('I go to organisation page')
+@step(u'I go to dataset page')
+def go_to_dataset_page(context):
+    when_i_visit_url(context, '/dataset')
+
+
+@step(u'I go to dataset "{name}"')
+def go_to_dataset(context, name):
+    when_i_visit_url(context, '/dataset/' + name)
+
+
+@step(u'I edit the "{name}" dataset')
+def edit_dataset(context, name):
+    when_i_visit_url(context, '/dataset/edit/{}'.format(name))
+
+
+@step(u'I go to organisation page')
 def go_to_organisation_page(context):
     when_i_visit_url(context, '/organization')
 
 
-@step('I go to register page')
-def go_to_register_page(context):
-    when_i_visit_url(context, '/user/register')
-
-
-@step('I log in and go to the data requests page')
+@step(u'I log in and go to the data requests page')
 def log_in_go_to_datarequest_page(context):
     assert context.persona
     context.execute_steps(u"""
@@ -72,12 +94,12 @@ def log_in_go_to_datarequest_page(context):
     """)
 
 
-@step('I go to the data requests page')
+@step(u'I go to the data requests page')
 def go_to_datarequest_page(context):
     when_i_visit_url(context, '/datarequest')
 
 
-@step('I log in and create a datarequest')
+@step(u'I log in and create a datarequest')
 def log_in_create_a_datarequest(context):
 
     assert context.persona
@@ -87,7 +109,7 @@ def log_in_create_a_datarequest(context):
     """)
 
 
-@step('I create a datarequest')
+@step(u'I create a datarequest')
 def create_datarequest(context):
 
     assert context.persona
@@ -100,19 +122,9 @@ def create_datarequest(context):
     """)
 
 
-@step('I go to my reports page')
+@step(u'I go to my reports page')
 def go_to_reporting_page(context):
     when_i_visit_url(context, '/dashboard/reporting')
-
-
-@step('I go to dataset page')
-def go_to_dataset_page(context):
-    when_i_visit_url(context, '/dataset')
-
-
-@step(u'I go to dataset "{name}"')
-def go_to_dataset(context, name):
-    when_i_visit_url(context, '/dataset/' + name)
 
 
 @step(u'I go to dataset "{name}" comments')

--- a/test/features/user_creation.feature
+++ b/test/features/user_creation.feature
@@ -26,7 +26,7 @@ Feature: User creation
 
     Scenario: Non logged-in user register to the site.
         Given "Unauthenticated" as the persona
-        When I go to "/user/register"
+        When I go to register page
         Then I should see "Displayed name"
         Then I fill in "name" with "publisher_user"
         Then I fill in "fullname" with "gov user"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -23,7 +23,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckan-ex-qgov.git"
-      version: "3.3.1"
+      version: "4.0.0"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -23,7 +23,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckan-ex-qgov.git"
-      version: "3.3.1"
+      version: "4.0.0"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -11,7 +11,7 @@ extensions:
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"
       shortname: "ckanext-qgov"
-      description: "CKAN Extension for Queensland Government Open Data"
+      description: "CKAN Extension for Queensland Government sites"
       type: "git"
       url: "https://github.com/qld-gov-au/ckan-ex-qgov.git"
       version: "4.0.0"
@@ -31,17 +31,6 @@ extensions:
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-ssm-config.git"
       version: "0.0.2"
-
-    # install Open Data extension under a different name,
-    # which signals to the cookbook that we only want
-    # the Publications-relevant parts
-    CKANExtDataQld: &CKANExtDataQld
-      name: "ckanext-publications-qld-{{ Environment }}"
-      shortname: "ckanext-publications-qld"
-      description: "CKAN Extension for Queensland Government Publications"
-      type: "git"
-      url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "4.0.1"
 
     CKANExtPublicationsTheme: &CKANExtPublicationsTheme
       name: "ckanext-publications-qld-theme-{{ Environment }}"
@@ -84,10 +73,6 @@ extensions:
 
     CKANExtSSMConfig:
       <<: *CKANExtSSMConfig
-      version: "develop"
-
-    CKANExtDataQld:
-      <<: *CKANExtDataQld
       version: "develop"
 
     CKANExtPublicationsTheme:

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -14,7 +14,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckan-ex-qgov.git"
-      version: "3.3.1"
+      version: "4.0.0"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"


### PR DESCRIPTION
This allows us to drop the ckanext-data-qld extension from Publications, so it won't be affected by Data-specific features.