### PR TITLE
[QOL-8612] update S3 filestore extension

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -31,7 +31,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.4-qgov"
+      version: "0.7.5-qgov"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -31,7 +31,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.4-qgov"
+      version: "0.7.5-qgov"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -22,7 +22,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.4-qgov"
+      version: "0.7.5-qgov"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"


### PR DESCRIPTION
- reduce task size in memory
- skip updated packages if privacy is unchanged
- add features to hide and delete non-current S3 objects
- degrade instead of breaking if Redis has errors
- strip double quotes from ETag values so Newrelic doesn't choke
- increase cache length for unsigned URLs