### PR TITLE
[QOL-7544] update test CKAN to be based on more recent upstream

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -237,5 +237,5 @@ basic_facts:
     Domain: "www.test-dev.data.qld.gov.au,test-dev.data.qld.gov.au"
     SiteDomain: "test-dev.data.qld.gov.au" #CKAN SiteDomain
     RootDomain: "test-dev.data.qld.gov.au" #ACM cert creation which also gets *.RootDomain
-    CKANRevision: "ckan-2.9.4-qgov.4"
+    CKANRevision: "ckan-2.9.5-qgov.1"
     CmsOrigin: "staging.squizedge.net"


### PR DESCRIPTION
Update base from 2.9.4 to 2.9.5 and reapply needed patches.

This should add Solr 8 support.

It also adds an option for restricting uploaded MIME types, similarly to ckanext-resource-type-validation but without the same emphasis on ensuring that formats and filenames and sniffed types are compatible. It may be worth incorporating these new config options into that extension.