### PR TITLE
[DC-31529][DC-31581][QOL-8842] update ckanext-data-qld to fix validation

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "6.2.0"
+      version: "6.3.0"
 
     CKANExtODICertificates: &CKANExtODICertificates
       name: "ckanext-odi-certificates-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "6.2.0"
+      version: "6.3.0"
 
     CKANExtODICertificates: &CKANExtODICertificates
       name: "ckanext-odi-certificates-{{ Environment }}"


### PR DESCRIPTION
Ignore 'nature_of_change' and 'next_update_due' fields in contexts where they're not applicable, eg when the 'update' is the XLoader adding metadata, or just resources being reordered.

- Also fix org and group DCTERMS metadata duplication
- Drop duplicate breadcrumb on resource pages