### PR TITLE
[DC-32816] update CKAN fork to patch sqlparse

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr7: "http://archive.apache.org/dist/lucene/solr/7.7.2/solr-7.7.2.zip"
-ckan_tag: "ckan-2.9.5-qgov.7"
+ckan_tag: "ckan-2.9.5-qgov.8"
 ckan_qgov_branch: "qgov-master-2.9.5"
 
 common_stack: &common_stack


### PR DESCRIPTION
- This was applied to 2.8 and upstream 2.10, but was overlooked for 2.9