### PR TITLE
QOL-9055 Configure instance operating system directly

### DIFF
--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -97,7 +97,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
-ckan.plugins = stats text_view image_view recline_view datastore data_qld data_qld_google_analytics scheming_datasets validation dcat qa archiver report harvester_data_qld_geoscience harvest qgovext ytp_comments datarequests xloader csrf_filter resource_type_validation ssm_config odi_certificates
+ckan.plugins = stats text_view image_view recline_view datastore data_qld data_qld_google_analytics scheming_datasets validation dcat qa archiver report harvester_data_qld_geoscience harvest qgovext ytp_comments datarequests xloader csrf_filter resource_type_validation odi_certificates
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.docker/test-Publications.ini
+++ b/.docker/test-Publications.ini
@@ -97,7 +97,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
-ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext csrf_filter resource_type_validation ssm_config
+ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext csrf_filter resource_type_validation
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -119,6 +119,10 @@ Parameters:
     Description: The base name for the exported application layer subnet IDs, eg if the exports are 'PRODMyApplicationAppSubnetA' and 'PRODMyApplicationAppSubnetB', then this would be 'PRODMyApplicationAppSubnet'. Only needed for HA configurations.
     Type: String
     Default: none
+  OperatingSystem:
+    Description: The operating system to install on all instances.
+    Type: String
+    Default: "Amazon Linux 2018.03"
 
 Conditions:
   2PlusServiceInstances:
@@ -198,6 +202,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref ServicesEC2Size
+      Os: !Ref OperatingSystem
       LayerIds:
         - Fn::ImportValue: !Ref SolrLayerID
       StackId:
@@ -234,6 +239,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref ServicesEC2Size
+      Os: !Ref OperatingSystem
       SubnetId:
         Fn::ImportValue: !Sub "${AppSubnets}B" #todo, can only change if hostname also is changed
       LayerIds:
@@ -273,6 +279,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref WebEC2Size
+      Os: !Ref OperatingSystem
       LayerIds:
         - Fn::ImportValue: !Ref WebLayerID
       StackId:
@@ -314,6 +321,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref WebEC2Size
+      Os: !Ref OperatingSystem
       SubnetId:
         Fn::ImportValue: !Sub "${AppSubnets}{{ subnetLetters[ loopingTimes % 3 ] }}"
 
@@ -358,6 +366,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref WebEC2Size
+      Os: !Ref OperatingSystem
       LayerIds:
         - Fn::ImportValue: !Ref WebLayerID
       StackId:
@@ -374,6 +383,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref WebEC2Size
+      Os: !Ref OperatingSystem
       SubnetId:
         Fn::ImportValue: !Sub "${AppSubnets}C"
       LayerIds:
@@ -393,6 +403,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref BatchEC2Size
+      Os: !Ref OperatingSystem
       LayerIds:
         - Fn::ImportValue: !Ref BatchLayerID
       StackId:
@@ -411,6 +422,7 @@ Resources:
       RootDeviceType: ebs
       InstallUpdatesOnBoot: true
       InstanceType: !Ref BatchEC2Size
+      Os: !Ref OperatingSystem
       LayerIds:
         - Fn::ImportValue: !Ref BatchLayerID
       StackId:

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -135,7 +135,7 @@ extensions:
       description: "CKAN Extension for Quality Assurance"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qa.git"
-      version: "2.0.3-qgov.6"
+      version: "2.0.3-qgov.7"
 
     CKANExtResourceTypeValidation: &CKANExtResourceTypeValidation
       name: "ckanext-resource-type-validation-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -135,7 +135,7 @@ extensions:
       description: "CKAN Extension for Quality Assurance"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qa.git"
-      version: "2.0.3-qgov.6"
+      version: "2.0.3-qgov.7"
 
     CKANExtResourceTypeValidation: &CKANExtResourceTypeValidation
       name: "ckanext-resource-type-validation-{{ Environment }}"


### PR DESCRIPTION
By specifying the operating system directly for each instance, rather than just setting a stack default, it will be easier for us to roll forward and back in future. Changing the value will trigger CloudFormation to replace each affected instance.