### PR TITLE
[QOL-9055] update Harvest to use release version

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -103,7 +103,7 @@ extensions:
       description: "CKAN Extension for Harvesting"
       type: "git"
       url: "https://github.com/ckan/ckanext-harvest.git"
-      version: "98edcd3ad7e3f6208797df90b7a4ebe76b1104d6"
+      version: "v1.4.1"
 
     CKANExtHarvestDataQldGeoScience: &CKANExtHarvestDataQldGeoScience
       name: "ckanext-harvest-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -103,7 +103,7 @@ extensions:
       description: "CKAN Extension for Harvesting"
       type: "git"
       url: "https://github.com/ckan/ckanext-harvest.git"
-      version: "98edcd3ad7e3f6208797df90b7a4ebe76b1104d6"
+      version: "v1.4.1"
 
     CKANExtHarvestDataQldGeoScience: &CKANExtHarvestDataQldGeoScience
       name: "ckanext-harvest-{{ Environment }}"


### PR DESCRIPTION
- pyOpenSSL fixes have now been released in v1.4.1, so drop the commit hash and use the tag