### PR TITLE
[QOLSVC-1280] downgrade XLoader to fix type guessing errors

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -14,8 +14,8 @@ extensions:
       shortname: "ckanext-xloader"
       description: "CKAN Express Loader Extension"
       type: "git"
-      url: "https://github.com/ckan/ckanext-xloader.git"
-      version: "0.12.2"
+      url: "https://github.com/qld-gov-au/ckanext-xloader.git"
+      version: "0.11.0-qgov.2"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -14,8 +14,8 @@ extensions:
       shortname: "ckanext-xloader"
       description: "CKAN Express Loader Extension"
       type: "git"
-      url: "https://github.com/ckan/ckanext-xloader.git"
-      version: "0.12.2"
+      url: "https://github.com/qld-gov-au/ckanext-xloader.git"
+      version: "0.11.0-qgov.2"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"


### PR DESCRIPTION
- The new tabulator-based type guessing is much more prone to encountering errors on data that the old system didn't mind. We need to downgrade until those are resolved.