### PR TITLE
QOLSVC-978 prepare for CKAN 2.10

### DIFF
--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -113,7 +113,6 @@ ckan.plugins =
     scheming_datasets
     qa archiver
     harvest harvester_data_qld_geoscience
-    odi_certificates
     resource_visibility
     ssm_config
     data_qld_test

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -55,7 +55,7 @@ extensions:
       description: "CKAN Extension for Scheming"
       type: "git"
       url: "https://github.com/ckan/ckanext-scheming.git"
-      version: "release-2.1.0"
+      version: "release-3.0.0"
 
     CKANExtValidation: &CKANExtValidation
       name: "ckanext-validation-{{ Environment }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -73,14 +73,6 @@ extensions:
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
       version: "7.0.0"
 
-    CKANExtODICertificates: &CKANExtODICertificates
-      name: "ckanext-odi-certificates-{{ Environment }}"
-      shortname: "ckanext-odi-certificates"
-      description: "CKAN Extension for ODI Certificates"
-      type: "git"
-      url: "https://github.com/qld-gov-au/ckanext-odi-certificates.git"
-      version: "1.0.3"
-
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
       shortname: "ckanext-datarequests"
@@ -194,10 +186,6 @@ extensions:
 
     CKANExtDataQld:
       <<: *CKANExtDataQld
-      version: "master"
-
-    CKANExtODICertificates:
-      <<: *CKANExtODICertificates
       version: "master"
 
     CKANExtDataRequests:

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -95,7 +95,7 @@ extensions:
       description: "CKAN Extension for YTP Comments"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-ytp-comments.git"
-      version: "2.5.0-qgov.9"
+      version: "2.5.0-qgov.10"
 
     CKANExtHarvest: &CKANExtHarvest
       name: "ckanext-harvest-{{ Environment }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -143,7 +143,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-csrf-filter.git"
-      version: "1.1.7"
+      version: "1.1.8"
 
     CKANExtValidationSchemaGenerator: &CKANExtValidationSchemaGenerator
       name: "ckanext-validation-schema-generator-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -73,14 +73,6 @@ extensions:
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
       version: "7.0.0"
 
-    CKANExtODICertificates: &CKANExtODICertificates
-      name: "ckanext-odi-certificates-{{ Environment }}"
-      shortname: "ckanext-odi-certificates"
-      description: "CKAN Extension for ODI Certificates"
-      type: "git"
-      url: "https://github.com/qld-gov-au/ckanext-odi-certificates.git"
-      version: "1.0.3"
-
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
       shortname: "ckanext-datarequests"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -55,7 +55,7 @@ extensions:
       description: "CKAN Extension for Scheming"
       type: "git"
       url: "https://github.com/ckan/ckanext-scheming.git"
-      version: "release-2.1.0"
+      version: "release-3.0.0"
 
     CKANExtValidation: &CKANExtValidation
       name: "ckanext-validation-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -188,10 +188,6 @@ extensions:
       <<: *CKANExtDataQld
       version: "develop"
 
-    CKANExtODICertificates:
-      <<: *CKANExtODICertificates
-      version: "develop"
-
     CKANExtDataRequests:
       <<: *CKANExtDataRequests
       version: "develop"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -151,7 +151,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-csrf-filter.git"
-      version: "1.1.7"
+      version: "1.1.8"
 
     CKANExtValidationSchemaGenerator: &CKANExtValidationSchemaGenerator
       name: "ckanext-validation-schema-generator-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -95,7 +95,7 @@ extensions:
       description: "CKAN Extension for YTP Comments"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-ytp-comments.git"
-      version: "2.5.0-qgov.9"
+      version: "2.5.0-qgov.10"
 
     CKANExtHarvest: &CKANExtHarvest
       name: "ckanext-harvest-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -54,7 +54,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-csrf-filter.git"
-      version: "1.1.7"
+      version: "1.1.8"
 
   PROD:
     <<: *default_extensions


### PR DESCRIPTION
- Update extensions to add CKAN 2.10 support.
- Remove ODI Certificates as it's obsolete and hard to update.