### PR TITLE
QOLDEV-347 update XLoader to prepare for CKAN 2.10 and fix timeouts

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -15,7 +15,7 @@ extensions:
       description: "CKAN Express Loader Extension"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-xloader.git"
-      version: "0.11.0-qgov.2"
+      version: "1.0.1-qgov.1"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -172,6 +172,10 @@ extensions:
 
   DEV:
     <<: *default_extensions
+    CKANExtXLoader:
+      <<: *CKANExtXLoader
+      version: "master"
+
     CKANExtQGOV:
       <<: *CKANExtQGOV
       version: "master"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -15,7 +15,7 @@ extensions:
       description: "CKAN Express Loader Extension"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-xloader.git"
-      version: "0.11.0-qgov.2"
+      version: "1.0.1-qgov.1"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -172,6 +172,10 @@ extensions:
 
   DEV:
     <<: *default_extensions
+    CKANExtXLoader:
+      <<: *CKANExtXLoader
+      version: "develop"
+
     CKANExtQGOV:
       <<: *CKANExtQGOV
       version: "develop"


### PR DESCRIPTION
Previous errors found in upstream have been fixed, we're back on our fork.

This includes a fix for the resource_data page timing out on very large resources.