### PR TITLE
[CHDEXCHAE-60] update Data theme with enhancements to hidden resources

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -19,6 +19,7 @@ commands:
   build-network:
     usage: Ensure that the amazeeio network exists.
     cmd: |
+      ahoy title "Creating amazeeio Docker network"
       docker network prune -f > /dev/null
       docker network inspect amazeeio-network > /dev/null || docker network create amazeeio-network
 
@@ -34,15 +35,15 @@ commands:
   up:
     usage: Build and start Docker containers.
     cmd: |
-      echo "Preparing containers for $VARS_TYPE"
+      ahoy title "Building and starting Docker containers for $VARS_TYPE"
       docker-compose up -d "$@"
-      sleep 10
-      docker-compose logs
-      ahoy cli "dockerize -wait tcp://ckan:5000 -timeout 1m"
-      if docker-compose logs | grep -q "\[Error\]"; then docker-compose logs; exit 1; fi
-      if docker-compose logs | grep -q "Exception"; then docker-compose logs; exit 1; fi
-      docker ps -a --filter name=^/${COMPOSE_PROJECT_NAME}_
+      echo "Initialising database schema"
       ahoy cli '$APP_DIR/bin/init.sh'
+      echo "Waiting for containers to start listening..."
+      ahoy cli "dockerize -wait tcp://ckan:5000 -timeout 1m"
+      if docker-compose logs | grep -q "\[Error\]"; then exit 1; fi
+      if docker-compose logs | grep -q "Exception"; then exit 1; fi
+      docker ps -a --filter name=^/${COMPOSE_PROJECT_NAME}_
       export DOCTOR_CHECK_CLI=0
 
   down:
@@ -86,6 +87,7 @@ commands:
   clean:
     usage: Remove containers and all build files.
     cmd: |
+      ahoy title "Cleaning up old builds"
       ahoy down
       # Remove other directories.
       # @todo: Add destinations below.
@@ -107,6 +109,7 @@ commands:
   lint:
     usage: Lint code.
     cmd: |
+      ahoy title 'Check for lint'
       ahoy cli "flake8 ${@:-roles}" || \
       [ "${ALLOW_LINT_FAIL:-0}" -eq 1 ]
 
@@ -120,12 +123,14 @@ commands:
   test-unit:
     usage: Run unit tests.
     cmd: |
+      ahoy title 'Run unit tests'
       ahoy cli 'pytest --ckan-ini=${CKAN_INI} $APP_DIR/test' || \
       [ "${ALLOW_UNIT_FAIL:-0}" -eq 1 ]
 
   test-bdd:
     usage: Run BDD tests.
     cmd: |
+      ahoy title 'Run scenario tests'
       ahoy cli "rm -f test/screenshots/*"
       ahoy start-ckan-job-workers
       ahoy start-mailmock &

--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -96,9 +96,9 @@ ckan.redis.url = redis://redis:6379
 ## Plugins Settings
 ckan.plugins =
     stats resource_proxy text_view webpage_view recline_grid_view image_view recline_view recline_graph_view recline_map_view
+    data_qld data_qld_google_analytics
     dcat structured_data
     validation
-    data_qld data_qld_google_analytics data_qld_integration
     resource_type_validation
     validation_schema_generator
     qgovext

--- a/bin/ckan_cli
+++ b/bin/ckan_cli
@@ -59,14 +59,14 @@ fi
 if [ "$COMMAND" = "ckan" ]; then
     # adjust args to match ckan expectations
     COMMAND=$(echo "$1" | sed -e 's/create-test-data/seed/')
-    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
+    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND $1..." >&2
     exec $ENV_DIR/ckan -c ${CKAN_INI} $COMMAND "$@" $CLICK_ARGS
 elif [ "$COMMAND" = "paster" ]; then
     # adjust args to match paster expectations
     COMMAND=$1
-    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
+    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND $1..." >&2
     if [ "$1" = "show" ]; then shift; fi
     exec $ENV_DIR/paster --plugin=$PASTER_PLUGIN $COMMAND "$@" -c ${CKAN_INI}
 else

--- a/bin/create-test-data-OpenData.sh
+++ b/bin/create-test-data-OpenData.sh
@@ -50,7 +50,6 @@ echo "Creating test users for ${DR_ORG_TITLE} Organisation:"
 
 add_user_if_needed dr_admin "Data Request Admin" dr_admin@localhost
 add_user_if_needed dr_editor "Data Request Editor" dr_editor@localhost
-add_user_if_needed dr_member "Data Request Member" dr_member@localhost
 
 echo "Creating ${DR_ORG_TITLE} Organisation:"
 
@@ -72,10 +71,6 @@ curl -LsH "Authorization: ${API_KEY}" \
     --data '{"id": "'"${DR_ORG_ID}"'", "object": "dr_editor", "object_type": "user", "capacity": "editor"}' \
     ${CKAN_ACTION_URL}/member_create
 
-curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'"${DR_ORG_ID}"'", "object": "dr_member", "object_type": "user", "capacity": "member"}' \
-    ${CKAN_ACTION_URL}/member_create
-
 echo "Creating test dataset for data request organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
@@ -95,16 +90,15 @@ curl -LsH "Authorization: ${API_KEY}" \
 #
 
 ##
-# BEGIN: Create a Reporting organisation with test users
+# BEGIN: Create a Reporting organisation
 #
 
 REPORT_ORG_NAME=reporting-org
 REPORT_ORG_TITLE="Reporting Organisation"
 
-echo "Creating test users for ${REPORT_ORG_TITLE} Organisation:"
+echo "Creating admin user for ${REPORT_ORG_TITLE} Organisation:"
 
 add_user_if_needed report_admin "Reporting Admin" report_admin@localhost
-add_user_if_needed report_editor "Reporting Editor" report_editor@localhost
 
 echo "Creating ${REPORT_ORG_TITLE} Organisation:"
 
@@ -116,23 +110,11 @@ REPORT_ORG=$( \
 
 REPORT_ORG_ID=$(echo $REPORT_ORG | $PYTHON $APP_DIR/bin/extract-id.py)
 
-echo "Assigning test users to ${REPORT_ORG_TITLE} Organisation:"
+echo "Assigning admin user to ${REPORT_ORG_TITLE} Organisation:"
 
 curl -LsH "Authorization: ${API_KEY}" \
     --data '{"id": "'"${REPORT_ORG_ID}"'", "object": "report_admin", "object_type": "user", "capacity": "admin"}' \
     ${CKAN_ACTION_URL}/member_create
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "'"${REPORT_ORG_ID}"'", "object": "report_editor", "object_type": "user", "capacity": "editor"}' \
-    ${CKAN_ACTION_URL}/member_create
-
-echo "Creating test dataset for reporting:"
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "reporting-dataset", "title": "Dataset for reporting", "owner_org": "'"${REPORT_ORG_ID}"'",
-"update_frequency": "near-realtime", "author_email": "report_admin@localhost", "version": "1.0", "license_id": "cc-by-4",
-"data_driven_application": "NO", "security_classification": "PUBLIC", "notes": "test", "de_identified_data": "NO"}'\
-    ${CKAN_ACTION_URL}/package_create
 
 echo "Creating test Data Request for reporting:"
 

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -92,7 +92,6 @@ organisation_create=$( \
 )
 echo ${organisation_create}
 
-add_user_if_needed foodie "Foodie" foodie@localhost
 add_user_if_needed group_admin "Group Admin" group_admin@localhost
 add_user_if_needed walker "Walker" walker@localhost
 
@@ -100,26 +99,10 @@ add_user_if_needed walker "Walker" walker@localhost
 
 echo "Assigning test Datasets to Organisation..."
 
-echo "Updating foodie to have admin privileges in the food-standards-agency Organisation:"
-foodie_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "food-standards-agency", "username": "foodie", "role": "admin"}' \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${foodie_update}
-
 echo "Creating non-organisation group:"
 group_create=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "silly-walks"}' \
-    ${CKAN_ACTION_URL}/group_create
-)
-echo ${group_create}
-
-echo "Creating Dave's Books group:"
-group_create=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "dave", "title": "Dave'"'"'s books", "description": "These are books that David likes."}' \
+    --data '{"name": "silly-walks", "title": "Silly walks", "description": "The Ministry of Silly Walks"}' \
     ${CKAN_ACTION_URL}/group_create
 )
 echo ${group_create}

--- a/bin/init-ext.sh
+++ b/bin/init-ext.sh
@@ -2,8 +2,7 @@
 ##
 # Install current extension.
 #
-set -e
-set -x
+set -ex
 
 install_requirements () {
     PROJECT_DIR=$1

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -7,6 +7,5 @@ set -e
 . ${APP_DIR}/bin/activate
 CLICK_ARGS="--yes" ckan_cli db clean
 ckan_cli db init
-ckan_cli db upgrade
 . $APP_DIR/bin/init-${VARS_TYPE}.sh
 

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -7,8 +7,10 @@ dockerize -wait tcp://redis:6379 -timeout 1m
 
 for i in `seq 1 60`; do
     if (PGPASSWORD=pass psql -h postgres -U ckan_default -d ckan_test -c "\q"); then
+        echo "Database became ready on attempt $i"
         break
     else
+        echo "Database not yet ready, retrying (attempt $i)..."
         sleep 1
     fi
 done

--- a/bin/test-bdd.sh
+++ b/bin/test-bdd.sh
@@ -5,5 +5,4 @@
 set -ex
 
 ahoy install-site
-echo "==> Run BDD tests"
 ahoy test-bdd

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,7 +2,6 @@
 ##
 # Run tests in CI.
 #
-set -e
+set -ex
 
-echo "==> Run Unit tests"
 ahoy test-unit

--- a/test/features/admin_reporting.feature
+++ b/test/features/admin_reporting.feature
@@ -40,36 +40,33 @@ Feature: AdminReporting
         Then I should see an element with xpath "//tr[@id='overdue-datasets']/td[contains(@class, 'metric-title') and contains(string(), 'Overdue Datasets') and position()=1]"
         And I should see an element with xpath "//tr[@id='overdue-datasets']/td[contains(@class, 'metric-data') and position()=2]"
 
-    Scenario: As an admin user of my organisation, when I view my admin report, I can verify that datasets without groups are identified
+    Scenario: As an admin user of my organisation, when I view my admin report, I can verify that datasets without groups or tags are identified
         Given "ReportingOrgAdmin" as the persona
         When I log in
+        And I create a dataset and resource with key-value parameters "title=Dataset for admin reporting" and "url=default"
         And I go to my reports page
         And I press "Admin Report"
         And I press the element with xpath "//button[contains(string(), 'Show')]"
         Then I should see an element with xpath "//tr[@id='datasets_no_groups']/td[contains(@class, 'metric-title') and position()=1]/a[contains(@href, 'datasets_no_groups?report_type=admin') and contains(string(), 'Datasets not added to group')]"
         And I should see an element with xpath "//tr[@id='datasets_no_groups']/td[contains(@class, 'metric-data') and position()=2]/a[contains(@href, 'datasets_no_groups?report_type=admin')]"
+        And I should see an element with xpath "//tr[@id='datasets_no_tags']/td[contains(@class, 'metric-title') and position()=1]/a[contains(@href, 'datasets_no_tags?report_type=admin') and contains(string(), 'Datasets with no tags')]"
+        And I should see an element with xpath "//tr[@id='datasets_no_tags']/td[contains(@class, 'metric-data') and position()=2]/a[contains(@href, 'datasets_no_tags?report_type=admin')]"
 
         When I press "Datasets not added to group/s"
         Then I should see "Admin Report: Datasets not added to group/s: Reporting Organisation"
-        And I should see "Dataset for reporting"
-        When I press "Dataset for reporting"
-        Then I should see "Dataset for reporting"
+        And I should see "Dataset for admin reporting"
+        When I press "Dataset for admin reporting"
+        Then I should see "Dataset for admin reporting"
         And I should see "Data and Resources"
 
-    Scenario: As an admin user of my organisation, when I view my admin report, I can verify that datasets without tags are identified
-        Given "ReportingOrgAdmin" as the persona
-        When I log in
-        And I go to my reports page
+        When I go to my reports page
         And I press "Admin Report"
         And I press the element with xpath "//button[contains(string(), 'Show')]"
-        Then I should see an element with xpath "//tr[@id='datasets_no_tags']/td[contains(@class, 'metric-title') and position()=1]/a[contains(@href, 'datasets_no_tags?report_type=admin') and contains(string(), 'Datasets with no tags')]"
-        And I should see an element with xpath "//tr[@id='datasets_no_tags']/td[contains(@class, 'metric-data') and position()=2]/a[contains(@href, 'datasets_no_tags?report_type=admin')]"
-
-        When I press "Datasets with no tags"
+        And I press "Datasets with no tags"
         Then I should see "Admin Report: Datasets with no tags: Reporting Organisation"
-        And I should see "Dataset for reporting"
-        When I press "Dataset for reporting"
-        Then I should see "Dataset for reporting"
+        And I should see "Dataset for admin reporting"
+        When I press "Dataset for admin reporting"
+        Then I should see "Dataset for admin reporting"
         And I should see "Data and Resources"
 
     Scenario: As an admin user of my organisation, when I view my admin report, I can verify de-identified datasets without default data schema

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -72,7 +72,6 @@ Feature: Data Request
         | User                  |
         | CKANUser              |
         | DataRequestOrgEditor  |
-        | DataRequestOrgMember  |
         | TestOrgEditor         |
         | TestOrgMember         |
 

--- a/test/features/dataset_schema.feature
+++ b/test/features/dataset_schema.feature
@@ -24,14 +24,14 @@ Feature: Dataset Schema
 
         Examples: roles
         | User                 |
-        | DataRequestOrgAdmin  |
-        | DataRequestOrgEditor |
+        | TestOrgAdmin  |
+        | TestOrgEditor |
 
     Scenario: New field visibility on dataset Additional info and API
         Given "SysAdmin" as the persona
         When I log in
         And I create a dataset and resource with key-value parameters "schema_json=default" and "url=default"
         Then I should see an element with xpath "//th[@class="dataset-label" and string()="Default data schema"]/following::a[string()="View Schema File"]"
-        Then I should see an element with xpath "//th[@class="dataset-label" and string()="Data schema validation options"]/following::td[@class="dataset-details" and string()="Field name 'validation_options' not in data"]"
+        Then I should see an element with xpath "//th[@class="dataset-label" and string()="Data schema validation options"]/following::td[@class="dataset-details" and string()="[blank]"]"
         When I visit "api/action/package_show?id=$last_generated_name"
         Then I should see an element with xpath "//body/*[contains(string(), '"default_data_schema":')]"

--- a/test/features/engagement_reporting.feature
+++ b/test/features/engagement_reporting.feature
@@ -54,9 +54,9 @@ Feature: Engagement Reporting
         And I should see an element with xpath "//tr[contains(@class, 'closing-circumstance')]/td[position()=1]/a[contains(@href, '/closed?') and contains(string(), 'To be released as open data at a later date')]"
         And I should see an element with xpath "//tr[contains(@class, 'closing-circumstance')]/td[position()=2]/a[contains(@href, '/closed?') and string()='0']"
 
-        When I go to dataset "reporting-dataset"
+        When I create a dataset and resource with key-value parameters "notes=Dataset for engagement reporting" and "url=default"
         And I press the element with xpath "//a[@class='btn btn-success' and contains(string(), 'Follow')]"
-        And I go to dataset "reporting-dataset" comments
+        And I go to dataset "$last_generated_name" comments
         And I submit a comment with subject "Test subject" and comment "This is a test comment"
         And I go to data request "Reporting Request" comments
         And I submit a comment with subject "Test subject" and comment "This is a test comment"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -38,11 +38,6 @@ PERSONAS = {
         'email': u'walker@localhost',
         'password': u'Password123!'
     },
-    'Foodie': {
-        'name': u'foodie',
-        'email': u'foodie@localhost',
-        'password': u'Password123!'
-    },
     # This user will not be assigned to any organisations
     'CKANUser': {
         'name': u'ckan_user',

--- a/test/features/google_analytics.feature
+++ b/test/features/google_analytics.feature
@@ -20,15 +20,13 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
-        # Can't use 'I press' because the text contains an apostrophe
-        # See https://github.com/ggozad/behaving/issues/137
-        When I click the link with text that contains "Dave's books"
+        When I press "Silly walks"
         And I press "About"
-        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and contains(@content, 'Dave')]"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and contains(@content, 'Silly walks')]"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and contains(@content, 'c=AU; o=The State of Queensland; ou=Dave') and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and contains(@content, 'c=AU; o=The State of Queensland; ou=Silly walks') and @scheme='AGLSTERMS.GOLD']"
         And I should see an element with xpath "//meta[@name='DCTERMS.created' and @content!='' and @content!='None']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='These are books that David likes.']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='The Ministry of Silly Walks']"
         And I should see an element with xpath "//meta[@name='DCTERMS.identifier' and @content!='' and @content!='None']"
         And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -33,7 +33,7 @@ Feature: Group APIs
     Scenario: Group overview is accessible to everyone
         Given "Unauthenticated" as the persona
         When I go to "/group"
-        Then I should see "silly-walks"
+        Then I should see "Silly walks"
         And I should not see an element with xpath "//a[contains(@href, '?action=read')]"
         And I should see an element with xpath "//a[contains(@href, '/group/silly-walks')]"
 

--- a/test/features/resource_align_default_schema.feature
+++ b/test/features/resource_align_default_schema.feature
@@ -7,7 +7,7 @@ Feature: Resource align_default_schema field
         When I log in
         And I create a dataset and resource with key-value parameters "schema_json=" and "upload=default::format=CSV"
         And I go to dataset "$last_generated_name"
-        Then I should see an element with xpath "//th[@class="dataset-label" and string()="Default data schema"]/following-sibling::td[contains(string(), "Field name 'default_data_schema' not in data")]"
+        Then I should see an element with xpath "//th[@class="dataset-label" and string()="Default data schema"]/following-sibling::td[contains(string(), "[blank]")]"
 
         When I go to the first resource in the dataset
         And I press the element with xpath "//a[contains(string(),'Manage')]"

--- a/test/features/resource_availability.feature
+++ b/test/features/resource_availability.feature
@@ -7,6 +7,11 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
         When I log in
         And I create a dataset and resource with key-value parameters "name=package-with-invisible-resource::notes=Package with invisible resource::de_identified_data=NO::private=False" and "name=invisible-resource::resource_visible=FALSE"
         Then I should see "invisible-resource"
+        And I should see "HIDDEN"
+        When I press "invisible-resource"
+        # Check that we made it to the resource page
+        Then I should see "Resource visible"
+        And I should see "HIDDEN"
 
         Given "CKANUser" as the persona
         When I log out
@@ -74,10 +79,14 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
         Given "TestOrgEditor" as the persona
         When I log in
         And I create a dataset and resource with key-value parameters "de_identified_data=NO" and "name=invisible-resource::resource_visible=FALSE"
+        And I should see "HIDDEN"
         And I press "invisible-resource"
+        And I should see "HIDDEN"
         And I press "Manage"
         Then I should not see an element with xpath "//label[@for="field-request_privacy_assessment"]//*[@class="control-required"]"
         And I should see an element with xpath "//select[@id="field-request_privacy_assessment"]//option[@value="" or @value="YES" or @value="NO"]"
+        And I should see "Privacy risk assessment prior to public release might assist the publishing decision-making process"
+        And I should see an element with xpath "//a[contains(@href, 'download') and contains(string(), 'Privacy assessment guidance')]"
 
         When I press the element with xpath "//button[string()='Update Resource']"
         Then I should see an element with xpath "//th[string()='Request privacy assessment']/following-sibling::td[not(string())]"
@@ -89,4 +98,7 @@ Feature: Re-identification risk governance acknowledgement or Resource visibilit
 
         When I log out
         And I go to dataset "package-without-de-identified-data"
-        Then I should see "visible-resource"
+        Then I should not see "HIDDEN"
+        And I should see "visible-resource"
+        And I click the link with text that contains "visible-resource"
+        And I should not see "HIDDEN"

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -22,16 +22,16 @@ Feature: Resource UI
     Scenario Outline: Add new resource metadata field on the create and edit resource GUI pages
         Given "<Persona>" as the persona
         When I log in
-        And I open the new resource form for dataset "data_request_dataset"
+        And I open the new resource form for dataset "public-test-dataset"
         Then I should see an element with xpath "//label[@for="field-request_privacy_assessment"]"
         And field "request_privacy_assessment" should not be required
         And I should not see an element with xpath "//label[@for="field-request_privacy_assessment"]//*[@class="control-required"]"
         And I should see an element with xpath "//select[@id="field-request_privacy_assessment"]//option[@value="" or @value="YES" or @value="NO"]"
-        And I should see "Where the dataset contains de-identified data, selecting ‘YES’ will hide this resource, pending a privacy assessment. Assessments will not be completed where the dataset does not contain de-identified data. Select ‘NO’ where the dataset does not contain de-identified data or where a privacy assessment is not required."
+        And I should see "Privacy risk assessment prior to public release might assist the publishing decision-making process."
         Examples: roles
         | Persona              |
-        | DataRequestOrgAdmin  |
-        | DataRequestOrgEditor |
+        | TestOrgAdmin  |
+        | TestOrgEditor |
 
     @Publications
     Scenario: Link resource with missing or invalid protocol should use HTTP

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -120,7 +120,7 @@ Feature: User APIs
 
     @email
     Scenario: As a registered user, when I have locked my account with too many failed logins, I can reset my password to unlock it
-        Given "Foodie" as the persona
+        Given "CKANUser" as the persona
         When I lock my account
         And I go to "/user/login"
         And I attempt to log in with password "$password"

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -45,7 +45,7 @@ common_stack: &common_stack
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
-    CookbookRevision: "{{ CookbookRevision | default('6.1.5') }}"
+    CookbookRevision: "{{ CookbookRevision | default('6.1.6') }}"
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr7 }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.1.0"
+      version: "7.2.0"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
@@ -159,7 +159,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-resource-visibility.git"
-      version: "2.1.0"
+      version: "2.1.1"
 
   PROD:
     <<: *default_extensions

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.1.0"
+      version: "7.2.0"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
@@ -159,7 +159,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-resource-visibility.git"
-      version: "2.1.0"
+      version: "2.1.1"
 
   PROD:
     <<: *default_extensions


### PR DESCRIPTION
- Show "HIDDEN" label on resources hidden for privacy reasons, update privacy assessment help text, hide the Request Privacy Assessment field from unprivileged access
- Make data request comments searchable
- Enable Recaptcha bot protection
- Adjust display of missing fields to be "[blank]" instead of a "not in data" message.
- Also prune unnecessary test data and adjust build order to run faster (initialise database while test CKAN instance is starting).