### PR TITLE
[QOLDEV-312] update CKAN 2.10 environment to use Solr 8

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -255,4 +255,5 @@ basic_facts:
     RootDomain: "test-dev.data.qld.gov.au" #ACM cert creation which also gets *.RootDomain
     CmsOrigin: "oss.squizedge.net"
     CKANRevision: "ckan-2.10.1-qgov.3"
+    SolrSource: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
 

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -254,6 +254,6 @@ basic_facts:
     SiteDomain: "test-dev.data.qld.gov.au" #CKAN SiteDomain
     RootDomain: "test-dev.data.qld.gov.au" #ACM cert creation which also gets *.RootDomain
     CmsOrigin: "oss.squizedge.net"
-    CKANRevision: "ckan-2.10.1-qgov.3"
+    CKANRevision: "ckan-2.10.1-qgov.4"
     SolrSource: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
 


### PR DESCRIPTION
- Solr 8 is the standard version for CKAN 2.10+ so we should start testing on it