### PR TITLE
[QOLSVC-978] downgrade to Solr 7

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -4,7 +4,7 @@ ProductionGTMId: "{{ lookup('aws_ssm', '/config/CKAN/GtmIdProduction', region=re
 NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction', region=region) }}"
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
-solr8: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
+solr_url: "http://archive.apache.org/dist/lucene/solr/7.7.2/solr-7.7.2.zip"
 ckan_tag: "ckan-2.10.1-qgov.7"
 ckan_qgov_branch: "qgov-master-2.10.1"
 
@@ -48,7 +48,7 @@ common_stack: &common_stack
     CookbookRevision: "{{ CookbookRevision | default('6.1.9') }}"
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
-    SolrSource: "{{ solr8 }}"
+    SolrSource: "{{ solr_url }}"
   tags: &common_stack_tags
     Environment: "{{ Environment }}"
     Service: "{{ service_name }}"


### PR DESCRIPTION
- Solr 8 has index upgrade problems. Solr 7 should be able to work with CKAN 2.10 for now.