### PR TITLE
[QOLDEV-349] update Geoscience harvester to replace obsolete validator

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -103,7 +103,7 @@ extensions:
       description: "CKAN Extension for Data Qld Harvesting Enhancements for Geoscience"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-harvester-data-qld-geoscience"
-      version: "v0.0.9"
+      version: "v0.0.10"
 
     CKANExtReport: &CKANExtReport
       name: "ckanext-report-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -103,7 +103,7 @@ extensions:
       description: "CKAN Extension for Data Qld Harvesting Enhancements for Geoscience"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-harvester-data-qld-geoscience"
-      version: "v0.0.9"
+      version: "v0.0.10"
 
     CKANExtReport: &CKANExtReport
       name: "ckanext-report-{{ Environment }}"


### PR DESCRIPTION
- 'unicode' validator no longer works in CKAN 2.10