### PR TITLE
[QOLDEV-638] update Open Data theme and data requests

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -148,8 +148,7 @@ commands:
       if [ "$BEHAVE_TAG" = "" ]; then
         # Run reporting tests last so numbers are consistent
         (ahoy cli "behave -k --tags=-OpenData --tags=-Publications ${*:-test/features}" \
-         && ahoy cli "behave -k --tags $VARS_TYPE --tags=-reporting ${*:-test/features}" \
-         && ahoy cli "behave -k --tags $VARS_TYPE --tags=reporting ${*:-test/features}" \
+         && ahoy cli "behave -k --tags $VARS_TYPE ${*:-test/features}" \
         ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
         # run tests with the specified tag

--- a/bin/create-test-data-OpenData.sh
+++ b/bin/create-test-data-OpenData.sh
@@ -2,8 +2,7 @@
 ##
 # Create example content specific to Open Data BDD tests.
 #
-set -e
-set -x
+set -ex
 
 ##
 # BEGIN: Add sysadmin config values.

--- a/bin/process-config.sh
+++ b/bin/process-config.sh
@@ -1,4 +1,4 @@
 if [ -d "$SRC_DIR/ckan/ckanext/activity" ]; then
-    sed -i 's|^ckan.plugins =|ckan.plugins = activity|' $CKAN_INI .docker/test-*.ini
+    sed -i 's|^ckan.plugins =|ckan.plugins = activity|' $CKAN_INI .docker/test*.ini
 fi
 

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -30,7 +30,7 @@ Feature: Comments
 
     @comment-add @datarequest
     Scenario: When a logged-in user submits a comment on a Data Request the comment should then be visible on the Comments tab of the Data Request
-        Given "CKANUser" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments
@@ -40,7 +40,7 @@ Feature: Comments
 
     @comment-add @datarequest @email
     Scenario: When a logged-in user submits a comment on a Data Request the email should contain title and comment
-        Given "CKANUser" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments
@@ -71,7 +71,7 @@ Feature: Comments
 
     @comment-add @comment-profane @datarequest
     Scenario: When a logged-in user submits a comment containing profanity on a Data Request they should receive an error message and the comment will not appear
-        Given "CKANUser" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments
@@ -96,7 +96,7 @@ Feature: Comments
 
     @comment-report @datarequest @email
     Scenario: When a logged-in user reports a comment on a Data Request the comment should be marked as reported and an email notification sent to the organisation admins
-        Given "CKANUser" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -92,7 +92,7 @@ Feature: Theme customisations (Publications and OpenData)
     Scenario: As a publisher, when I create a resource with an API entry, I can download it in various formats
         Given "TestOrgEditor" as the persona
         When I log in
-        And I create a dataset and resource with key-value parameters "license=other-open::private=False" and "format=CSV::upload=csv_resource.csv"
+        And I create a dataset and resource with key-value parameters "license=other-open" and "format=CSV::upload=csv_resource.csv"
         And I wait for 10 seconds
         And I press "Test Resource"
         Then I should see an element with xpath "//a[contains(string(), 'Data API')]"

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -58,10 +58,10 @@ Feature: Data Request
         Given "TestOrgEditor" as the persona
         When I log in
         And I go to the data requests page
-        And I press "Add Data Request"
+        And I press "Add data request"
         And I fill in title with random text
         And I fill in "description" with "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
-        And I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Create Data Request')]"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Create data request')]"
         Then I should see "Blocked due to profanity" within 5 seconds
 
     Scenario: Data request creator and Sysadmin can see a 'Close' button on the data request detail page for opened data requests
@@ -141,7 +141,7 @@ Feature: Data Request
         When I log in
         And I create a datarequest
         And I go to the data requests page
-        And I press "Add Data Request"
+        And I press "Add data request"
         And I fill in title with random text
         And I fill in "description" with "Test throttling"
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -54,6 +54,16 @@ Feature: Data Request
         And I should see an element with the css selector "span.error-block" within 1 seconds
         And I should see "Description cannot be empty" within 1 seconds
 
+    Scenario: When a logged-in user submits a Data Request containing profanity they should receive an error message and the request will not be created
+        Given "TestOrgEditor" as the persona
+        When I log in
+        And I go to the data requests page
+        And I press "Add Data Request"
+        And I fill in title with random text
+        And I fill in "description" with "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
+        And I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Create Data Request')]"
+        Then I should see "Blocked due to profanity" within 5 seconds
+
     Scenario: Data request creator and Sysadmin can see a 'Close' button on the data request detail page for opened data requests
         Given "SysAdmin" as the persona
         When I log in
@@ -91,6 +101,51 @@ Feature: Data Request
         And I press the element with xpath "//button[contains(@class, 'btn-danger') and contains(string(), 'Close data request')]"
         Then I should see an element with xpath "//i[contains(@class, 'icon-lock')]"
         And I should not see an element with xpath "//a[contains(string(), 'Close')]"
+
+    Scenario: Delete all data requests for a user
+        # Use a different profile so we don't delete any other test requests
+        Given "TestOrgAdmin" as the persona
+        When I log in
+        And I create a datarequest
+        And I create a datarequest
+        And I create a datarequest
+        And I go to the "test_org_admin" profile page
+        And I take a debugging screenshot
+        And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
+        And I take a debugging screenshot
+        Then I should see an element with xpath "//a[@title='Delete' and contains(@class, 'btn-danger')]"
+        And I should not see an element with xpath "//a[contains(@class, 'btn-danger-serious')]"
+
+        Given "SysAdmin" as the persona
+        When I log out
+        And I log in
+        And I go to the "test_org_admin" profile page
+        And I take a debugging screenshot
+        And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
+        And I take a debugging screenshot
+        Then I should see an element with xpath "//a[@title='Delete' and contains(@class, 'btn-danger')]"
+        And I should see an element with xpath "//a[contains(@title, 'Delete all') and contains(@class, 'btn-danger-serious')]"
+
+        When I press the element with xpath "//a[contains(@title, 'Delete all') and contains(@class, 'btn-danger-serious')][1]"
+        And I take a debugging screenshot
+        And I confirm the dialog containing "Are you sure you want to" if present
+        And I take a debugging screenshot
+        Then I should see an element with xpath "//div[contains(@class, 'alert') and contains(string(), 'Deleted') and contains(string(), 'data request(s)')]"
+
+        When I go to the "test_org_admin" profile page
+        And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
+        Then I should see "No data requests found"
+
+    Scenario: An unprivileged user who tries to create multiple data requests close together should see an error
+        Given "CKANUser" as the persona
+        When I log in
+        And I create a datarequest
+        And I go to the data requests page
+        And I press "Add Data Request"
+        And I fill in title with random text
+        And I fill in "description" with "Test throttling"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
+        Then I should see "Too many requests submitted, please wait"
 
     Scenario: As an org admin I can re-open a closed data request
         Given "DataRequestOrgAdmin" as the persona

--- a/test/features/engagement_reporting.feature
+++ b/test/features/engagement_reporting.feature
@@ -23,32 +23,19 @@ Feature: Engagement Reporting
             | TestOrgAdmin  |
             | TestOrgEditor |
 
-    Scenario: As a data request organisation admin, when I view my engagement report, I can verify the number of data requests is correct and increments
-        Given "DataRequestOrgAdmin" as the persona
-        When I log in
-        And I go to my reports page
-        And I press "Engagement Report"
-        And I press the element with xpath "//button[contains(string(), 'Show')]"
-        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
-        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='30' and position()=2]"
-
-        When I create a datarequest
-        And I go to my reports page
-        And I press "Engagement Report"
-        And I press the element with xpath "//button[contains(string(), 'Show')]"
-        Then I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
-        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='31' and position()=2]"
-
     Scenario: As an admin user of my organisation, when I view my engagement report, I can verify the numbers are correct and increment
         Given "ReportingOrgAdmin" as the persona
         When I log in
         And I go to my reports page
         And I press "Engagement Report"
+        And I take a debugging screenshot
         And I press the element with xpath "//button[contains(string(), 'Show')]"
         Then I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-title') and string()='Dataset followers' and position()=1]"
         And I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"
         And I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-title') and string()='Dataset comments' and position()=1]"
         And I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"
+        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
+        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
         And I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-title') and string()='Data request comments' and position()=1]"
         And I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-data') and string()='0' and position()=2]"
         And I should see an element with xpath "//tr[contains(@class, 'closing-circumstance')]/td[position()=1]/a[contains(@href, '/closed?') and contains(string(), 'To be released as open data at a later date')]"
@@ -62,6 +49,7 @@ Feature: Engagement Reporting
         And I submit a comment with subject "Test subject" and comment "This is a test comment"
         And I go to data request "Reporting Request" comments
         And I submit a comment with subject "Test subject" and comment "This is a test comment"
+        And I create a data request in the "Reporting Organisation" organisation
         And I go to data request "Reporting Request"
         And I press the element with xpath "//a[contains(string(), 'Close')]"
         And I select "To be released as open data at a later date" from "close_circumstance"
@@ -75,6 +63,8 @@ Feature: Engagement Reporting
         And I should see an element with xpath "//tr[@id='dataset-followers']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
         And I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-title') and string()='Dataset comments' and position()=1]"
         And I should see an element with xpath "//tr[@id='dataset-comments']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
+        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-title') and string()='Data requests' and position()=1]"
+        And I should see an element with xpath "//tr[@id='datarequests-total']/td[contains(@class, 'metric-data') and string()='2' and position()=2]"
         And I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-title') and string()='Data request comments' and position()=1]"
         And I should see an element with xpath "//tr[@id='datarequest-comments']/td[contains(@class, 'metric-data') and string()='1' and position()=2]"
         And I should see an element with xpath "//tr[contains(@class, 'closing-circumstance')]/td[position()=1]/a[contains(@href, '/closed?') and contains(string(), 'To be released as open data at a later date')]"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -741,13 +741,23 @@ def go_to_data_request(context, subject):
 def create_datarequest(context):
     assert context.persona
     context.execute_steps(u"""
+        When I create a data request in the "Open Data Administration" organisation
+    """)
+
+
+@when(u'I create a data request in the "{organisation_name}" organisation')
+def create_datarequest_for_org(context, organisation_name):
+    assert context.persona
+    context.execute_steps(u"""
         When I go to the data requests page
         And I press "Add data request"
         And I fill in title with random text
         And I fill in "description" with "Test description"
-        And I execute the script "$('#field-organizations option:contains("Open Data Administration")').attr('selected', true)"
+        And I execute the script "$('#field-organizations option:contains("{0}")').attr('selected', true)"
+        And I take a debugging screenshot
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
-    """)
+        And I take a debugging screenshot
+    """.format(organisation_name))
 
 
 @when(u'I go to data request "{subject}" comments')

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -45,7 +45,7 @@ common_stack: &common_stack
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
-    CookbookRevision: "{{ CookbookRevision | default('6.1.12') }}"
+    CookbookRevision: "{{ CookbookRevision | default('6.1.13') }}"
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr_url }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.2.5"
+      version: "7.2.6"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
@@ -79,7 +79,7 @@ extensions:
       description: "CKAN Extension for Data Requests"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-datarequests.git"
-      version: "2.2.1-qgov.10"
+      version: "2.2.1-qgov.11"
 
     CKANExtYTP: &CKANExtYTP
       name: "ckanext-ytp-comments-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -71,7 +71,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.2.5"
+      version: "7.2.6"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"
@@ -79,7 +79,7 @@ extensions:
       description: "CKAN Extension for Data Requests"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-datarequests.git"
-      version: "2.2.1-qgov.10"
+      version: "2.2.1-qgov.11"
 
     CKANExtYTP: &CKANExtYTP
       name: "ckanext-ytp-comments-{{ Environment }}"


### PR DESCRIPTION
- Move customisations from theme to ckanext-datarequests so we don't have to double up on them