### PR TITLE
[QOLDEV-640] update CKAN core to disable caching on logout URL

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.1-qgov.7"
+ckan_tag: "ckan-2.10.1-qgov.8"
 ckan_qgov_branch: "qgov-master-2.10.1"
 
 common_stack: &common_stack


### PR DESCRIPTION
- If /user/_logout is cached then it doesn't delete the session cookie