### PR TITLE
QOLDEV-683 update YTP Comments to fix profanity filter

### DIFF
--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -60,6 +60,16 @@ Feature: Comments
         Then I should see "Comment blocked due to profanity" within 5 seconds
 
     @comment-add @comment-profane
+    Scenario: When a logged-in user submits a comment containing profanity with special symbols on a dataset they should receive an error message and the comment will not appear
+        Given "TestOrgEditor" as the persona
+        When I log in
+        And I create a dataset with key-value parameters "notes=Profane Dataset Comment with regex characters"
+        And I go to dataset "$last_generated_name" comments
+        Then I should see the add comment form
+        When I submit a comment with subject "Test subject" and comment "Rachel Lindt's cape name is Bi+ch."
+        Then I should see "Comment blocked due to profanity" within 5 seconds
+
+    @comment-add @comment-profane
     Scenario: When a logged-in user submits a comment containing whitelisted profanity on a Dataset the comment should display within 10 seconds
         Given "TestOrgEditor" as the persona
         When I log in

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -24,6 +24,7 @@ if not hasattr(forms, 'fill_in_elem_by_name'):
 
 URL_RE = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|\
                     (?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I | re.S | re.U)
+SINGLE_QUOTE_RE = re.compile(r"(^|[^\\])'")
 
 dataset_default_schema = """
     {"fields": [
@@ -152,7 +153,8 @@ def confirm_dialog_if_present(context, text):
         return
     button_xpath = parent_xpath + "//button[contains(@class, 'btn-primary')]"
     context.execute_steps(u"""
-        When I press the element with xpath "{0}"
+        When I take a debugging screenshot
+        And I press the element with xpath "{0}"
     """.format(button_xpath))
 
 
@@ -658,6 +660,13 @@ def comment_form_not_visible(context):
     """)
 
 
+def escape_for_javascript_string(text):
+    """ Escape a text so that it's suitable to be injected into a
+    single-quoted JavaScript string.
+    """
+    return SINGLE_QUOTE_RE.sub(r"\1\\'", text)
+
+
 @when(u'I submit a comment with subject "{subject}" and comment "{comment}"')
 def submit_comment_with_subject_and_comment(context, subject, comment):
     """
@@ -670,10 +679,10 @@ def submit_comment_with_subject_and_comment(context, subject, comment):
     """
     context.browser.execute_script("""
         document.querySelector('form#comment_form input[name="subject"]').value = '%s';
-        """ % subject)
+        """ % escape_for_javascript_string(subject))
     context.browser.execute_script("""
         document.querySelector('form#comment_form textarea[name="comment"]').value = '%s';
-        """ % comment)
+        """ % escape_for_javascript_string(comment))
     context.browser.execute_script("""
         document.querySelector('form#comment_form .form-actions input[type="submit"]').click();
         """)

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -87,7 +87,7 @@ extensions:
       description: "CKAN Extension for YTP Comments"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-ytp-comments.git"
-      version: "2.5.0-qgov.15"
+      version: "2.5.0-qgov.16"
 
     CKANExtHarvest: &CKANExtHarvest
       name: "ckanext-harvest-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -87,7 +87,7 @@ extensions:
       description: "CKAN Extension for YTP Comments"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-ytp-comments.git"
-      version: "2.5.0-qgov.15"
+      version: "2.5.0-qgov.16"
 
     CKANExtHarvest: &CKANExtHarvest
       name: "ckanext-harvest-{{ Environment }}"


### PR DESCRIPTION
We have forked the profanityfilter library so we can fix its handling of regex-significant characters, see https://github.com/areebbeigh/profanityfilter/issues/25