### PR TITLE
[QOLSVC-3914] update CKAN fork to detect when logged in

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.1-qgov.11"
+ckan_tag: "ckan-2.10.1-qgov.12"
 ckan_qgov_branch: "qgov-master-2.10.1"
 
 common_stack: &common_stack

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.1-qgov.12"
+ckan_tag: "ckan-2.10.1-qgov.13"
 ckan_qgov_branch: "qgov-master-2.10.1"
 
 common_stack: &common_stack


### PR DESCRIPTION
- CKAN 2.10's caching can sometimes make a page incorrectly appear logged out. This change injects a snippet of JavaScript to detect that we're logged in and offer to reload.