### PR TITLE
[QOLSVC-4214] update S3 Filestore plugin

### DIFF
--- a/check_ext_versions.py
+++ b/check_ext_versions.py
@@ -6,10 +6,10 @@ import six
 import yaml
 
 
-def check_version(current_version, repo_name):
-    latest_tag = os.popen("./get_latest_tag.sh " + repo_name, 'r').readline().strip()
+def check_version(current_version, repo_name, branch=''):
+    latest_tag = os.popen("./get_latest_tag.sh " + repo_name + ' ' + branch, 'r').readline().strip()
     if latest_tag and latest_tag != current_version:
-        print("{}: {} is using version [{}] but [{}] is available".format(
+        print("{}: {} is using version [{}] but [{}] is newer".format(
             app, repo_name, current_version, latest_tag
         ))
 
@@ -21,10 +21,11 @@ for app in ['OpenData', 'Publications', 'CKANTest']:
     for key, value in six.iteritems(extensions):
         check_version(value['version'], value['shortname'])
 
-template_parameters = yaml.safe_load(open('vars/CKAN-Stack.var.yml'))[
-    'cloudformation_stacks'][0]['template_parameters']
+stack_vars = yaml.safe_load(open('vars/CKAN-Stack.var.yml'))
+template_parameters = stack_vars['cloudformation_stacks'][0]['template_parameters']
 match = re.search("[^']'([-a-z0-9.]+)'[^']", template_parameters['CookbookRevision'])
 if match:
     check_version(match.group(1), 'ckan_cookbook')
 else:
     print("Unable to locate cookbook version in " + template_parameters['CookbookRevision'])
+check_version(stack_vars['ckan_tag'], 'ckan', stack_vars['ckan_qgov_branch'])

--- a/get_latest_tag.sh
+++ b/get_latest_tag.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 <directory>" >&2
+    echo "Usage: $0 <directory> [branch]" >&2
     exit 1
 fi
 GIT_DIR=../$1/.git
@@ -10,5 +10,25 @@ if ! [ -e "$GIT_DIR" ]; then
     exit 1
 fi
 
+git --git-dir="$GIT_DIR" fetch >/dev/null
 git --git-dir="$GIT_DIR" fetch --tags >/dev/null
-git --git-dir="$GIT_DIR" tag -l --sort=committerdate | tail -1
+TAG=$(git --git-dir="$GIT_DIR" tag -l --sort=committerdate | tail -1)
+BRANCH="$2"
+if [ "$BRANCH" = "" ]; then
+    if (git --git-dir="$GIT_DIR" branch -r |grep origin/main 2>&1 >/dev/null); then
+        BRANCH=main
+    elif (git --git-dir="$GIT_DIR" branch -r |grep origin/master 2>&1 >/dev/null); then
+        BRANCH=master
+    fi
+fi
+
+if [ "$BRANCH" = "" ]; then
+    echo $TAG
+else
+    DIFF=$(git --git-dir="$GIT_DIR" diff --stat "$TAG" "origin/$BRANCH")
+    if [ "$DIFF" = "" ]; then
+        echo $TAG
+    else
+        echo $BRANCH
+    fi
+fi

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -31,7 +31,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.7-qgov.7"
+      version: "0.7.7-qgov.8"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -151,7 +151,7 @@ extensions:
       description: "CKAN Extension for Schema Generation"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-validation-schema-generator.git"
-      version: "1.0.2"
+      version: "1.0.3"
 
     CKANExtResourceVisibility: &CKANExtResourceVisibility
       name: "ckanext-resource-visibility-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -31,7 +31,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.7-qgov.7"
+      version: "0.7.7-qgov.8"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -151,7 +151,7 @@ extensions:
       description: "CKAN Extension for Schema Generation"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-validation-schema-generator.git"
-      version: "1.0.2"
+      version: "1.0.3"
 
     CKANExtResourceVisibility: &CKANExtResourceVisibility
       name: "ckanext-resource-visibility-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -22,7 +22,7 @@ extensions:
       description: "CKAN Extension to keep uploaded files in S3"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-s3filestore.git"
-      version: "0.7.7-qgov.7"
+      version: "0.7.7-qgov.8"
 
     CKANExtSSMConfig: &CKANExtSSMConfig
       name: "ckanext-ssm-config-{{ Environment }}"


### PR DESCRIPTION
- Fix CKAN 2.10 compatibility
- Only update S3 object visibility if we're updating the dataset or uploading a new file, to reduce churn on background jobs