### PR TITLE
QOLSVC-4217 update QA and Archiver to fix report page errors under CKAN 2.10

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -146,7 +146,6 @@ commands:
       ahoy start-mailmock &
       sleep 5
       if [ "$BEHAVE_TAG" = "" ]; then
-        # Run reporting tests last so numbers are consistent
         (ahoy cli "behave -k --tags=-OpenData --tags=-Publications ${*:-test/features}" \
          && ahoy cli "behave -k --tags $VARS_TYPE ${*:-test/features}" \
         ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -149,9 +149,17 @@ commands:
         (ahoy cli "behave -k --tags=-OpenData --tags=-Publications ${*:-test/features}" \
          && ahoy cli "behave -k --tags $VARS_TYPE ${*:-test/features}" \
         ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      elif [ "$BEHAVE_TAG" = "app" ]; then
+        # run app-specific tests
+        ahoy cli "behave -k ${*:-test/features} --tags=-unauthenticated --tags=-smoke --tags=$VARS_TYPE" \
+          || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      elif [ "$BEHAVE_TAG" = "authenticated" ]; then
+        # run any tests that don't have a specific tag
+        ahoy cli "behave -k ${*:-test/features} --tags=-unauthenticated --tags=-smoke --tags=-OpenData --tags=-Publications" \
+          || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
         # run tests with the specified tag
-        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG" \
+        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=-OpenData --tags=-Publications" \
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       fi
       ahoy stop-mailmock

--- a/.github/workflows/test-staging.yml
+++ b/.github/workflows/test-staging.yml
@@ -10,19 +10,21 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: true
       matrix:
         application: [OpenData, Publications]
         python-version: [py3]
         target_environment: [STAGING]
-      fail-fast: true
+        behave-tag: [smoke, unauthenticated, app, authenticated]
 
-    name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} infrastructure build
+    name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} ${{ matrix.behave-tag }} infrastructure build
     runs-on: ubuntu-latest
     container: drevops/ci-builder:23.7.0
     env:
       VARS_TYPE: ${{ matrix.application }}
       DEPLOY_ENV: ${{ matrix.target_environment }}
       PYTHON_VERSION: ${{ matrix.python-version }}
+      BEHAVE_TAG: ${{ matrix.behave-tag }}
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +38,8 @@ jobs:
         run: bin/test-lint.sh
         timeout-minutes: 30
 
-      - name: Test
+      - name: Unit tests
+        if: ${{ matrix.behave-tag == 'smoke' }}
         run: bin/test.sh
         timeout-minutes: 40
 
@@ -58,6 +61,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} screenshots
+          name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} ${{ matrix.behave-tag }} screenshots
           path: /tmp/artifacts/behave/screenshots
         timeout-minutes: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,21 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: true
       matrix:
         application: [OpenData, Publications]
         python-version: [py3]
         target_environment: [DEV]
-      fail-fast: false
+        behave-tag: [smoke, unauthenticated, app, authenticated]
 
-    name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} infrastructure build
+    name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} ${{ matrix.behave-tag }} infrastructure build
     runs-on: ubuntu-latest
     container: drevops/ci-builder:23.7.0
     env:
       VARS_TYPE: ${{ matrix.application }}
       DEPLOY_ENV: ${{ matrix.target_environment }}
       PYTHON_VERSION: ${{ matrix.python-version }}
+      BEHAVE_TAG: ${{ matrix.behave-tag }}
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +37,8 @@ jobs:
         run: bin/test-lint.sh
         timeout-minutes: 30
 
-      - name: Test
+      - name: Unit tests
+        if: ${{ matrix.behave-tag == 'smoke' }}
         run: bin/test.sh
         timeout-minutes: 40
 
@@ -57,6 +60,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} screenshots
+          name: ${{ matrix.application }} ${{ matrix.target_environment }} ${{ matrix.python-version }} ${{ matrix.behave-tag }} screenshots
           path: /tmp/artifacts/behave/screenshots
         timeout-minutes: 1

--- a/bin/create-test-data-OpenData.sh
+++ b/bin/create-test-data-OpenData.sh
@@ -34,9 +34,12 @@ curl -LsH "Authorization: ${API_KEY}" \
 "license_id": "other-open", "data_driven_application": "NO", "security_classification": "PUBLIC",
 "notes": "public test", "de_identified_data": "NO", "resources": [
     {"name": "test-resource", "description": "Test resource description",
-     "url": "https://example.com", "format": "HTML", "size": 1024}
+     "url": "https://example.com/foo", "format": "HTML", "size": 1024}
 ]}' \
     ${CKAN_ACTION_URL}/package_create
+
+# Populate Archiver data for test dataset
+ckan_cli archiver update-test public-test-dataset
 
 ##
 # BEGIN: Create a Data Request organisation with test users for admin, editor and member and default data requests

--- a/test/features/reporting.feature
+++ b/test/features/reporting.feature
@@ -12,12 +12,37 @@ Feature: Reporting
         And I should see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Broken links')]"
         And I should see an element with xpath "//table[@id='report-table']//td[position()=1]/a[contains(@href, 'report/broken-links') and contains(string(), 'Test Organisation')]"
 
+        When I press "Test Organisation"
+        # There may not be an org with broken links, but we can at least check we've reached the org page
+        Then I should see an element with xpath "//a[@href="/report/broken-links" and string() = 'Index of all organizations']"
+        And I should not see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Percent broken')]"
+
+        When I go back
+        Then I should see an element with xpath "//select[@name='organization']"
+        When I select "test-organisation" from "organization"
+        Then I should see an element with xpath "//a[@href="/report/broken-links" and string() = 'Index of all organizations']"
+        And I should not see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Percent broken')]"
+
     @unauthenticated
     Scenario: I can view a 'Data Usability Rating' report anonymously
         Given "Unauthenticated" as the persona
         When I visit "/report"
         And I press "Data usability rating"
         Then I should see an element with xpath "//select[@name='organization']"
-        And I should see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Score TBC')]"
-        And I should see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Average score')]"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Score TBC']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Average score']"
         And I should see an element with xpath "//table[@id='report-table']//td[position()=1]/a[contains(@href, 'report/openness') and contains(string(), 'Test Organisation')]"
+
+        When I press "Test Organisation"
+        Then I should see an element with xpath "//table[@id='report-table']//th[string() = 'Dataset']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Notes']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Score']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Reason']"
+
+        When I go back
+        Then I should see an element with xpath "//select[@name='organization']"
+        When I select "test-organisation" from "organization"
+        Then I should see an element with xpath "//table[@id='report-table']//th[string() = 'Dataset']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Notes']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Score']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Reason']"

--- a/test/features/reporting.feature
+++ b/test/features/reporting.feature
@@ -13,15 +13,18 @@ Feature: Reporting
         And I should see an element with xpath "//table[@id='report-table']//td[position()=1]/a[contains(@href, 'report/broken-links') and contains(string(), 'Test Organisation')]"
 
         When I press "Test Organisation"
-        # There may not be an org with broken links, but we can at least check we've reached the org page
-        Then I should see an element with xpath "//a[@href="/report/broken-links" and string() = 'Index of all organizations']"
-        And I should not see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Percent broken')]"
+        Then I should see an element with xpath "//table[@id='report-table']//th[string() = 'Res']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'URL']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Status']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Reason']"
 
         When I go back
         Then I should see an element with xpath "//select[@name='organization']"
         When I select "test-organisation" from "organization"
-        Then I should see an element with xpath "//a[@href="/report/broken-links" and string() = 'Index of all organizations']"
-        And I should not see an element with xpath "//table[@id='report-table']//th[contains(string(), 'Percent broken')]"
+        Then I should see an element with xpath "//table[@id='report-table']//th[string() = 'Res']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'URL']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Status']"
+        And I should see an element with xpath "//table[@id='report-table']//th[string() = 'Reason']"
 
     @unauthenticated
     Scenario: I can view a 'Data Usability Rating' report anonymously

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -119,7 +119,7 @@ extensions:
       description: "CKAN Extension for Archiving needed for ckanext-qa"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-archiver.git"
-      version: "2.1.1-qgov.15"
+      version: "2.1.1-qgov.16"
 
     CKANExtQa: &CKANExtQa
       name: "ckanext-qa-{{ Environment }}"

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -127,7 +127,7 @@ extensions:
       description: "CKAN Extension for Quality Assurance"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qa.git"
-      version: "2.0.3-qgov.9"
+      version: "2.0.3-qgov.10"
 
     CKANExtResourceTypeValidation: &CKANExtResourceTypeValidation
       name: "ckanext-resource-type-validation-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -119,7 +119,7 @@ extensions:
       description: "CKAN Extension for Archiving needed for ckanext-qa"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-archiver.git"
-      version: "2.1.1-qgov.15"
+      version: "2.1.1-qgov.16"
 
     CKANExtQa: &CKANExtQa
       name: "ckanext-qa-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -127,7 +127,7 @@ extensions:
       description: "CKAN Extension for Quality Assurance"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qa.git"
-      version: "2.0.3-qgov.9"
+      version: "2.0.3-qgov.10"
 
     CKANExtResourceTypeValidation: &CKANExtResourceTypeValidation
       name: "ckanext-resource-type-validation-{{ Environment }}"


### PR DESCRIPTION
Both QA and Archiver reports (`/report/broken-links` and `/report/openness`) had failures under CKAN 2.10 when an organisation was selected, although the page was intact before that point. Scenario tests are now expanded to cover this case, and the underlying errors are fixed.