### PR TITLE
[QOLSVC-3902] update XLoader

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -15,7 +15,7 @@ extensions:
       description: "CKAN Express Loader Extension"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-xloader.git"
-      version: "1.0.1-qgov.6"
+      version: "1.0.1-qgov.7"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -15,7 +15,7 @@ extensions:
       description: "CKAN Express Loader Extension"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-xloader.git"
-      version: "1.0.1-qgov.6"
+      version: "1.0.1-qgov.7"
 
     CKANExtQGOV: &CKANExtQGOV
       name: "ckanext-qgov-{{ Environment }}"


### PR DESCRIPTION
- Add 'Delete datastore' button to remove current datastore
- Adjust loading process to truncate tables when structure is unchanged, instead of dropping and recreating them
- Record guessed types as overrides so they're persistent, unless manually changed