### PR TITLE
[QOLSVC-4446] update CKAN core to improve loading speed of large news feeds

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.1-qgov.13"
+ckan_tag: "ckan-2.10.1-qgov.14"
 ckan_qgov_branch: "qgov-master-2.10.1"
 
 common_stack: &common_stack


### PR DESCRIPTION
Adapted from work by Eric Soroos. Convert from outer join to subquery for better use of indexing. This cuts load times on large feeds by about 30%.