### PR TITLE
[QOLDEV-545] disable default OpsWorks security groups

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
@@ -444,6 +444,7 @@ Resources:
               - !Ref "AWS::AccountId"
               - ":role/aws-opsworks-service-role"
       UseCustomCookbooks: true
+      UseOpsworksSecurityGroups: false
       VpcId:
         Fn::ImportValue: !Ref StackVPC
 


### PR DESCRIPTION
- We manage our own groups, and the default groups cause problems for the export script

See https://old.reddit.com/r/aws/comments/13untfl/aws_opsworks_stacks_migration_to_systems_manager/