### PR TITLE
[QOLDEV-727] update CKAN core to fix trash page

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.3-qgov.4"
+ckan_tag: "ckan-2.10.3-qgov.5"
 ckan_qgov_branch: "qgov-master-2.10.3"
 
 common_stack: &common_stack


### PR DESCRIPTION
- Fall back to default 'dataset' type when custom type fails