### PR TITLE
[QOLDEV-545] provide the site URL via Chef custom JSON

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml
@@ -393,6 +393,7 @@ Resources:
         datashades:
           ckan_web:
             title: !Sub "${ApplicationTitle} | Queensland Government"
+            site_domain: !Ref SiteDomain
             email_domain: !Ref EmailDomain
             adminpw: !Ref CKANAdminPW
             adminemail: !Ref CKANAdminEmail


### PR DESCRIPTION
- This will allow the cookbook to populate the CKAN site URL without depending on OpsWorks app definitions. It's more appropriate anyway since the domain is not specific to each plugin.