### PR TITLE
[QOLDEV-545] fix app source parameter name

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -413,7 +413,7 @@ Resources:
               app_source:
                 type: git
                 url: !Ref CKANSource
-                version: !Ref CKANRevision
+                revision: !Ref CKANRevision
             plugin_apps:
 {% for plugin in extensions[Environment] %}
               - name: "{{ extensions[Environment][plugin].name }}"


### PR DESCRIPTION
- Cookbook expects 'revision' not 'version', to match the names used by OpsWorks apps