### PR TITLE
[QOLDEV-545] add capabilities to Chef deployment script

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -161,7 +161,7 @@ commands:
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
         # run tests with the specified tag
-        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG" \
+        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=-OpenData --tags=-Publications" \
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       fi
       ahoy stop-mailmock

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -161,7 +161,7 @@ commands:
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
         # run tests with the specified tag
-        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=-OpenData --tags=-Publications" \
+        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG" \
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       fi
       ahoy stop-mailmock

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -160,9 +160,10 @@ commands:
         ahoy cli "behave -k ${*:-test/features} --tags=-unauthenticated --tags=-smoke --tags=-OpenData --tags=-Publications" \
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
-        # run tests with the specified tag
-        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=-OpenData --tags=-Publications" \
-          || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+        # run shared or app-specific tests with the specific tag
+        (ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=-OpenData --tags=-Publications" \
+         && ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG --tags=$VARS_TYPE" \
+        ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       fi
       ahoy stop-mailmock
       ahoy stop-ckan-job-workers

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -50,6 +50,6 @@ Feature: Resource UI
     Scenario: Link resource with missing or invalid protocol should use HTTP
         Given "SysAdmin" as the persona
         When I log in
-        And I create a dataset and resource with key-value parameters "title=Non-HTTP resource" and "name=Non-HTTP link::url=git+https://github.com/ckan/ckan.git"
+        And I create a dataset and resource with key-value parameters "notes=Testing invalid link protocol" and "name=Non-HTTP link::url=git+https://github.com/ckan/ckan.git"
         And I press "Non-HTTP link"
         Then I should see "http://git+https://github.com/ckan/ckan.git"


### PR DESCRIPTION
- Automatically deregister instances from load balancers during non-parallel deployments
- Add support for executing multiple recipes at once, eg setup + deploy