### PR TITLE
[QOLSVC-5162] increase Solr instance sizes

### DIFF
--- a/vars/instances-OpenData.var.yml
+++ b/vars/instances-OpenData.var.yml
@@ -26,7 +26,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      SolrEC2Size: t3a.small
+      SolrEC2Size: t3a.medium
       WebEC2Size: t3a.medium
       BatchEC2Size: t3a.medium
       WebEC2Count: 5 #We have been running on 2 auto and 3 manually created instances, time to make it IasC
@@ -40,7 +40,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       Environment: STAGING
       WebEC2Count: 2
-      SolrEC2Size: t3a.small
+      SolrEC2Size: t3a.medium
       WebEC2Size: t3a.medium
       BatchEC2Size: t3a.medium
     tags:


### PR DESCRIPTION
- Production and Staging Solr instances are low on available memory, likely due to the large number of datasets.

Note that this is bypassing 'develop' as that contains unrelated and potentially unstable changes.