### PR TITLE
[QOLDEV-545] replace OpsWorks custom JSON with SSM parameters

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -139,15 +139,6 @@ Parameters:
   SSMKey:
     Type: String
     Description: KMS key for alias/aws/ssm
-  GTMContainerId:
-    Description: Google Tag Manager container ID
-    Type: String
-  AnalyticsId:
-    Description: Google Analytics container ID
-    Type: String
-  LogBucketName:
-    Description: Name of the S3 logging bucket.
-    Type: String
   AttachmentsBucketName:
     Description: Name of the S3 Attachment bucket.
     Type: String

--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -350,6 +350,161 @@ Resources:
       Roles:
         - !Ref WebInstanceRole
 
+  # Populate SSM Parameter Store with all the information needed to deploy.
+  # This should allow a blank instance to set itself up based only on the tags applied to it.
+
+  PublicTLDParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/public_tld"
+      Type: String
+      Value: !Ref PublicTLD
+
+  InternalHostedZoneTLDParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/tld"
+      Type: String
+      Value:
+        Fn::ImportValue: !Ref InternalStackZoneTLD
+
+  TitleParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/title"
+      Type: String
+      Value: !Sub "${ApplicationTitle} | Queensland Government"
+
+  SiteDomainParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/site_domain"
+      Type: String
+      Value: !Ref SiteDomain
+
+  EmailDomainParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/email_domain"
+      Type: String
+      Value: !Ref EmailDomain
+
+  DataStoreEnableParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ds_enable"
+      Type: String
+      Value: !Ref EnableDataStore
+
+  CKANAppNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/name"
+      Type: String
+      Value: !Sub "${ApplicationName}-${Environment}"
+
+  CKANAppShortNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/shortname"
+      Type: String
+      Value: !Sub "${ApplicationId}-${Environment}"
+
+  CKANAppSourceTypeParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/app_source/type"
+      Type: String
+      Value: git
+
+  CKANAppSourceURLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/app_source/url"
+      Type: String
+      Value: !Ref CKANSource
+
+  CKANAppSourceRevisionParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/app_source/revision"
+      Type: String
+      Value: !Ref CKANRevision
+
+  SolrAppNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/name"
+      Type: String
+      Value: !Sub "${ApplicationName}-${Environment}-solr"
+
+  SolrAppShortNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/shortname"
+      Type: String
+      Value: !Sub "${ApplicationId}-${Environment}-solr"
+
+  SolrAppSourceTypeParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/app_source/type"
+      Type: String
+      Value: archive
+
+  SolrAppSourceURLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/app_source/url"
+      Type: String
+      Value: !Ref SolrSource
+
+  PluginListParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_app_names"
+      Type: String
+      Value: "{{ extensions[Environment] | join(',') }}"
+
+{% for plugin in extensions[Environment] %}
+  {{ plugin }}AppNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_apps/{{ plugin }}/name"
+      Type: String
+      Value: "{{ extensions[Environment][plugin].name }}"
+
+  {{ plugin }}AppShortNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_apps/{{ plugin }}/shortname"
+      Type: String
+      Value: "{{ extensions[Environment][plugin].shortname }}"
+
+  {{ plugin }}AppSourceTypeParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_apps/{{ plugin }}/app_source/type"
+      Type: String
+      Value: git
+
+  {{ plugin }}AppSourceURLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_apps/{{ plugin }}/app_source/url"
+      Type: String
+      Value: "{{ extensions[Environment][plugin].url }}"
+
+  {{ plugin }}AppSourceRevisionParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/plugin_apps/{{ plugin }}/app_source/revision"
+      Type: String
+      Value: "{{ extensions[Environment][plugin].version }}"
+{% endfor %}
+
+  # OpsWorks stack layers
+
   OpsWorksStack:
     Type: AWS::OpsWorks::Stack
     Properties:
@@ -362,50 +517,6 @@ Resources:
         Type: !Ref CookbookURLType
         # SshKey: !Sub "${CookbookSSHKey}\n"
         Url: !Ref CookbookURL
-      CustomJson:
-        datashades:
-          ckan_web:
-            title: !Sub "${ApplicationTitle} | Queensland Government"
-            site_domain: !Ref SiteDomain
-            email_domain: !Ref EmailDomain
-            dsenable: !Ref EnableDataStore
-            endpoint: /
-            google:
-              gtm_container_id: !Ref GTMContainerId
-              analytics_id: !Ref AnalyticsId
-            ckan_app:
-              name: !Sub "${ApplicationName}-${Environment}"
-              shortname: !Sub "${ApplicationId}-${Environment}"
-              app_source:
-                type: git
-                url: !Ref CKANSource
-                revision: !Ref CKANRevision
-            plugin_apps:
-{% for plugin in extensions[Environment] %}
-              - name: "{{ extensions[Environment][plugin].name }}"
-                shortname: "{{ extensions[Environment][plugin].shortname }}"
-                app_source:
-                  type: "{{ extensions[Environment][plugin].type }}"
-                  url: "{{ extensions[Environment][plugin].url }}"
-                  revision: "{{ extensions[Environment][plugin].version}}"
-{% endfor %}
-          solr_app:
-            name: !Sub "${ApplicationName}-${Environment}-solr"
-            shortname: !Sub "${ApplicationId}-${Environment}-solr"
-            app_source:
-              type: archive
-              url: !Ref SolrSource
-          redis:
-            hostname:
-              Fn::ImportValue: !Ref CacheAddress
-            port: !Ref CachePort
-          tld:
-            Fn::ImportValue: !Ref InternalStackZoneTLD
-          public_tld: !Ref PublicTLD
-          version: !Ref Environment
-          app_id: !Ref ApplicationId
-          log_bucket: !Ref LogBucketName
-          attachments_bucket: !Ref AttachmentsBucketName
       DefaultInstanceProfileArn:
         Fn::GetAtt:
           - InstanceRoleProfile

--- a/templates/chef.json.j2
+++ b/templates/chef.json.j2
@@ -4,7 +4,7 @@
   "app_id": "{{ ApplicationId }}",
   "version": "{{ Environment }}",
   "ckan_web": {
-    "title": "{{ ApplicationTitle }}",
+    "title": "{{ ApplicationTitle }} | Queensland Government",
     "site_domain": "{{ SiteDomain }}",
     "email_domain": "{{ EmailDomain }}",
     "dsenable": "{{ EnableDataStore }}",

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -1,9 +1,4 @@
 ---
-NonProductionGTMId: "{{ lookup('aws_ssm', '/config/CKAN/GtmIdNonProduction', region=region) }}"
-ProductionGTMId: "{{ lookup('aws_ssm', '/config/CKAN/GtmIdProduction', region=region) }}"
-NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction', region=region) }}"
-ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
-
 solr_url: "http://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
 ckan_tag: "ckan-2.10.3-qgov.5"
 ckan_qgov_branch: "qgov-master-2.10.4"
@@ -42,7 +37,6 @@ common_stack: &common_stack
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
     CookbookRevision: "{{ CookbookRevision | default('7.0.3') }}"
-    LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr_url }}"
   tags: &common_stack_tags
@@ -58,8 +52,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      GTMContainerId: "{{ ProductionGTMId }}"
-      AnalyticsId: "{{ ProductionAnalyticsId }}"
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"
@@ -69,8 +61,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      GTMContainerId: "{{ NonProductionGTMId }}"
-      AnalyticsId: "{{ NonProductionAnalyticsId }}"
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"
@@ -80,8 +70,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: TRAINING
-      GTMContainerId: "{{ NonProductionGTMId }}"
-      AnalyticsId: "{{ NonProductionAnalyticsId }}"
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"
@@ -96,8 +84,6 @@ cloudformation_stacks:
       CookbookURL: "{{ CookbookURL | default('https://github.com/qld-gov-au/opswx-ckan-cookbook.git') }}"
       CookbookURLType: "{{ CookbookURLType | default('git')}}"
       CookbookRevision: "{{ CookbookRevision | default('develop') }}"
-      GTMContainerId: "{{ NonProductionGTMId }}"
-      AnalyticsId: "{{ NonProductionAnalyticsId }}"
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"


### PR DESCRIPTION
- Add SSM Parameter Store entries for each value, so that servers can retrieve them without needing any extra input. The server tags should provide enough information to locate the parameter values.
- Drop custom JSON in OpsWorks stack (to keep template size within the limit).
- Fix site title to include 'Queensland Government'.