### PR TITLE
[QOLDEV-545] move instance profiles back to their original stack

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -186,6 +186,22 @@ Resources:
                 Effect: Allow
                 Resource: "*"
 
+  InstanceRoleProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - Fn::ImportValue:
+            !Sub "${Environment}${ApplicationName}InstanceRole"
+
+  WebInstanceRoleProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - Fn::ImportValue:
+            !Sub "${Environment}${ApplicationName}WebInstanceRole"
+
   # Populate SSM Parameter Store with all the information needed to deploy.
   # This should allow a blank instance to set itself up based only on the tags applied to it.
 
@@ -417,8 +433,9 @@ Resources:
           log_bucket: !Ref LogBucketName
           attachments_bucket: !Ref AttachmentsBucketName
       DefaultInstanceProfileArn:
-        Fn::ImportValue:
-          !Sub "${Environment}${ApplicationName}InstanceRole"
+        Fn::GetAtt:
+          - InstanceRoleProfile
+          - Arn
       DefaultOs: "Amazon Linux 2"
       DefaultSshKeyName: !Ref DefaultEC2Key
       DefaultSubnetId:
@@ -490,8 +507,9 @@ Resources:
         - Fn::ImportValue: !Ref AdminSG
         - Fn::ImportValue: !Ref AppSG
       CustomInstanceProfileArn:
-        Fn::ImportValue:
-          !Sub "${Environment}${ApplicationName}WebInstanceRole"
+        Fn::GetAtt:
+          - WebInstanceRoleProfile
+          - Arn
       EnableAutoHealing: true
       InstallUpdatesOnBoot: true
       Name: !Sub "${ApplicationName}-Web"
@@ -538,8 +556,9 @@ Resources:
         - Fn::ImportValue: !Ref AdminSG
         - Fn::ImportValue: !Ref AppSG
       CustomInstanceProfileArn:
-        Fn::ImportValue:
-          !Sub "${Environment}${ApplicationName}WebInstanceRole"
+        Fn::GetAtt:
+          - WebInstanceRoleProfile
+          - Arn
       EnableAutoHealing: true
       InstallUpdatesOnBoot: true
       Name: !Sub "${ApplicationName}-Batch"

--- a/templates/instance-roles.cfn.yml
+++ b/templates/instance-roles.cfn.yml
@@ -142,13 +142,6 @@ Resources:
         - arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess # for domain name lookups
         - arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess # for domain name lookups
 
-  InstanceRoleProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties:
-      Path: /
-      Roles:
-        - !Ref InstanceRole
-
   WebInstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -185,28 +178,15 @@ Resources:
         - arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess # for domain name lookups
         - arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess # for domain name lookups
 
-  WebInstanceRoleProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties:
-      Path: /
-      Roles:
-        - !Ref WebInstanceRole
-
 Outputs:
-  InstanceRoleARN:
-    Value:
-      Fn::GetAtt:
-        - InstanceRoleProfile
-        - Arn
+  InstanceRole:
+    Value: !Ref InstanceRole
     Description: Resource identifier for the global instance role
     Export:
       Name: !Sub "${Environment}${ApplicationName}InstanceRole"
 
-  WebInstanceRoleARN:
-    Value:
-      Fn::GetAtt:
-        - WebInstanceRoleProfile
-        - Arn
+  WebInstanceRole:
+    Value: !Ref WebInstanceRole
     Description: Resource identifier for the web instance role
     Export:
       Name: !Sub "${Environment}${ApplicationName}WebInstanceRole"


### PR DESCRIPTION
- Changing instance profile ARNs is problematic since all servers need to be dropped and recreated to use the new profile. Keep the profiles in the same stack, just move the roles and policies.