### PR TITLE
[QOLDEV-818] add hosted zone to Parameter Store as a shared parameter

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -358,6 +358,7 @@ Resources:
                   - ssm:GetParametersByPath
                 Resource:
                   - !Sub "arn:aws:ssm:*:*:parameter/config/CKAN/${Environment}/app/${ApplicationId}/cookbook/*"
+                  - !Sub "arn:aws:ssm:*:*:parameter/config/CKAN/${Environment}/app/${ApplicationId}/ckan_app/*"
                   - !Sub "arn:aws:ssm:*:*:parameter/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/*"
                   - !Sub "arn:aws:ssm:*:*:parameter/config/CKAN/${Environment}/common/*"
       ManagedPolicyArns:

--- a/templates/hosted-zone.cfn.yml
+++ b/templates/hosted-zone.cfn.yml
@@ -31,6 +31,13 @@ Resources:
       HostedZoneConfig:
         Comment: !Sub "Internal resources for the ${Environment} Open Data and Publications environments"
 
+  InternalHostedZoneTLDParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/common/tld"
+      Type: String
+      Value: !GetAtt HostedZone.Name
+
 Outputs:
   ZoneID:
     Value: !Ref HostedZone


### PR DESCRIPTION
- Previously added as an app-specific parameter, which is unnecessary duplication and complications the permissions.