### PR TITLE
[QOLDEV-818] specify zone name manually

### DIFF
--- a/templates/hosted-zone.cfn.yml
+++ b/templates/hosted-zone.cfn.yml
@@ -36,7 +36,7 @@ Resources:
     Properties:
       Name: !Sub "/config/CKAN/${Environment}/common/tld"
       Type: String
-      Value: !GetAtt HostedZone.Name
+      Value: !Sub "${Environment}.ckan.internal"
 
 Outputs:
   ZoneID:


### PR DESCRIPTION
- 'Name' isn't an exported property of HostedZone