### PR TITLE
[QOLDEV-833] use custom AMIs for Open Data DEV batch and Solr instances

### DIFF
--- a/vars/instances-OpenData.var.yml
+++ b/vars/instances-OpenData.var.yml
@@ -11,7 +11,6 @@ common_stack: &common_stack
     OpsWorksStackID: "{{ Environment }}{{ service_name }}OpsWorksStack"
     SolrLayerID: "{{ Environment }}{{ service_name }}OpsWorksSolrLayer"
     WebLayerID: "{{ Environment }}{{ service_name }}OpsWorksWebLayer"
-    WebImageId: "ami-06ee65395f3227133"
     WebEC2Size: t3a.medium
     BatchLayerID: "{{ Environment }}{{ service_name }}OpsWorksBatchLayer"
     BatchEC2Size: t3a.medium
@@ -67,6 +66,9 @@ cloudformation_stacks:
       WebEC2Count: 2
       SolrEC2Size: t3a.small
       SolrEC2Count: 1
+      WebImageId: "ami-06ee65395f3227133"
+      BatchImageID: "ami-00126961217adc996"
+      SolrImageID: "ami-0db57769637120945"
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"


### PR DESCRIPTION
- Usable AMIs have been generated by AWS Backup