### PR TITLE
QOLDEV-819 refine autoscaling deployments

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -103,7 +103,7 @@ Parameters:
   WebEC2Count:
     Description: The number of active EC2 instances to create in the web layer.
     Type: Number
-    Default: 1
+    Default: 2
     MinValue: 1
     MaxValue: 6
   AppSubnets:

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -126,75 +126,6 @@ Parameters:
     Description: Select an existing SSH key
     Type: AWS::EC2::KeyPair::KeyName
 
-Conditions:
-  2PlusServiceInstances:
-    !Equals [ !Ref SolrEC2Count, 2 ]
-  2PlusWebInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: WebEC2Count
-      - '2'
-    - !Condition 3PlusWebInstances
-  3PlusWebInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: WebEC2Count
-      - '3'
-    - !Condition 4PlusWebInstances
-  4PlusWebInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: WebEC2Count
-      - '4'
-    - !Condition 5PlusWebInstances
-  5PlusWebInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: WebEC2Count
-      - '5'
-    - !Condition 6PlusWebInstances
-  6PlusWebInstances:
-    Fn::Equals:
-    - Ref: WebEC2Count
-    - '6'
-
-  BatchLayerNeeded: #batch is background
-    !Not [!Equals [!Ref BatchEC2Size, none]]
-  1PlusBatchInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: BatchEC2Count
-      - '1'
-    - !Condition 2PlusBatchInstances
-  2PlusBatchInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: BatchEC2Count
-      - '2'
-    - !Condition 3PlusBatchInstances
-  3PlusBatchInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: BatchEC2Count
-      - '3'
-    - !Condition 4PlusBatchInstances
-  4PlusBatchInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: BatchEC2Count
-      - '4'
-    - !Condition 5PlusBatchInstances
-  5PlusBatchInstances:
-    Fn::Or:
-    - Fn::Equals:
-      - Ref: BatchEC2Count
-      - '5'
-    - !Condition 6PlusBatchInstances
-  6PlusBatchInstances:
-    Fn::Equals:
-    - Ref: BatchEC2Count
-    - '6'
-
 Resources:
 
   # Autoscaling instances
@@ -241,26 +172,28 @@ Resources:
               FUNCTION_NAME=$(aws ssm get-parameter --region "${AWS::Region}" --name "/config/CKAN/${Environment}/app/${ApplicationId}/cookbook/setup_function_name" --query "Parameter.Value" --output text)
               aws lambda invoke --region "${AWS::Region}" --function-name "$FUNCTION_NAME" --payload '{"EC2InstanceId": "'$INSTANCE_ID'", "phase": "setup"}' /var/log/instance-setup.log.`date '+%s'`
 
+{% if layer == 'Web' %}
+{% set minInstanceCount = (item.template_parameters['WebEC2Count'] | int) - 1 %}
+{% else %}
+{% set minInstanceCount = 1 %}
+{% endif %}
+
   {{ layer }}ScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       AutoScalingGroupName: !Sub "${Environment}-${ApplicationName}-{{ layer }}-ASG"
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: {{ (item.template_parameters['WebEC2Count'] | int) - 1}}
+      MinSize: {{ minInstanceCount }}
       MaxSize: 6
       LaunchTemplate:
         LaunchTemplateId: !Ref {{ layer }}LaunchTemplate
         Version: !GetAtt {{ layer }}LaunchTemplate.LatestVersionNumber
+      DefaultInstanceWarmup: 1200
+      HealthCheckGracePeriod: 1200
 {% if layer == 'Web' %}
       TargetGroupARNs:
         - Fn::ImportValue: !Sub "${Environment}${ApplicationName}{{ layer }}AlbTargetGroup"
       HealthCheckType: ELB
-      HealthCheckGracePeriod: 1200
-{% endif %}
-{% if layer == 'Batch' %}
-      DefaultInstanceWarmup: 600
-{% else %}
-      DefaultInstanceWarmup: 1200
 {% endif %}
       VPCZoneIdentifier:
         - Fn::ImportValue: !Sub "${AppSubnets}A"
@@ -284,7 +217,7 @@ Resources:
     Type: AWS::AutoScaling::ScheduledAction
     Properties:
       AutoScalingGroupName: !Ref {{ layer }}ScalingGroup
-      MinSize: 1
+      MinSize: {{ minInstanceCount }}
       MaxSize: 6
       Recurrence: "0 20 * * *"
 {% endif %}

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -246,7 +246,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Sub "${Environment}-${ApplicationName}-{{ layer }}-ASG"
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: 1
+      MinSize: {{ (template_parameters | int) - 1}}
       MaxSize: 6
       LaunchTemplate:
         LaunchTemplateId: !Ref {{ layer }}LaunchTemplate

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -246,7 +246,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Sub "${Environment}-${ApplicationName}-{{ layer }}-ASG"
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: !Ref {{ layer }}EC2Count
+      MinSize: 1
       MaxSize: 6
       LaunchTemplate:
         LaunchTemplateId: !Ref {{ layer }}LaunchTemplate
@@ -284,7 +284,7 @@ Resources:
     Type: AWS::AutoScaling::ScheduledAction
     Properties:
       AutoScalingGroupName: !Ref {{ layer }}ScalingGroup
-      MinSize: !Ref {{ layer }}EC2Count
+      MinSize: 1
       MaxSize: 6
       Recurrence: "0 20 * * *"
 {% endif %}

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -246,7 +246,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Sub "${Environment}-${ApplicationName}-{{ layer }}-ASG"
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: {{ (template_parameters | int) - 1}}
+      MinSize: {{ (item.template_parameters['WebEC2Count'] | int) - 1}}
       MaxSize: 6
       LaunchTemplate:
         LaunchTemplateId: !Ref {{ layer }}LaunchTemplate

--- a/vars/instances-CKANTest.var.yml
+++ b/vars/instances-CKANTest.var.yml
@@ -56,7 +56,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: DEV
-      WebEC2Count: 2
+      WebEC2Count: 1
       SolrEC2Size: t3a.micro
       SolrEC2Count: 1
       WebEC2Size: t3a.micro

--- a/vars/instances-OpenData.var.yml
+++ b/vars/instances-OpenData.var.yml
@@ -59,7 +59,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: DEV
-      WebEC2Count: 2
+      WebEC2Count: 1
       SolrEC2Size: t3a.small
       SolrEC2Count: 1
     tags:

--- a/vars/instances-Publications.var.yml
+++ b/vars/instances-Publications.var.yml
@@ -66,6 +66,7 @@ cloudformation_stacks:
       Environment: DEV
       SolrEC2Size: t3a.micro
       SolrEC2Count: 1
+      WebEC2Count: 1
       WebEC2Size: t3a.micro
       BatchEC2Size: t3a.micro
     tags:


### PR DESCRIPTION
- Put instances into standby before deploying to them, instead of launching an instance refresh. This should be faster as we don't need to recreate machines from scratch every time.
- Adjust minimum autoscaling sizes to allow instances to go into standby.