### PR TITLE
[QOLDEV-819] specify default web instance count in Jinja

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -173,7 +173,7 @@ Resources:
               aws lambda invoke --region "${AWS::Region}" --function-name "$FUNCTION_NAME" --payload '{"EC2InstanceId": "'$INSTANCE_ID'", "phase": "setup"}' /var/log/instance-setup.log.`date '+%s'`
 
 {% if layer == 'Web' %}
-{% set minInstanceCount = (item.template_parameters['WebEC2Count'] | int) - 1 %}
+{% set minInstanceCount = (item.template_parameters['WebEC2Count'] | default('2') | int) - 1 %}
 {% else %}
 {% set minInstanceCount = 1 %}
 {% endif %}


### PR DESCRIPTION
- Jinja can't access the CloudFormation defaults, so if the count wasn't in the explicit parameters, it needs its own default set