### PR TITLE
[QOLDEV-819] exclude Solr instances from power management

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -209,7 +209,7 @@ Resources:
           Value: {{ layer|lower }}
           PropagateAtLaunch: true
 
-{% if item.tags["PowerManaged"] == "Yes" %}
+{% if item.tags["PowerManaged"] == "Yes" and layer != 'Solr' %}
   {{ layer }}ScalingIn:
     Type: AWS::AutoScaling::ScheduledAction
     Properties:


### PR DESCRIPTION
- Recreating Solr instances doesn't preserve the index. TODO Fix index sync so new instances can pick up the latest index.