### PR TITLE
[QOLDEV-839] drop OpsWorks resources (stack and layers) and documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Author: qol.development@smartservice.qld.gov.au
 
-**Full one click deployment of Datashared AWS OpsWorks Stack via Ansible**
+**Full one click deployment of CKAN AWS Stack via Ansible**
 
 This stands up the www.data.qld.gov.au and www.publications.qld.gov.au aws stacks using:
 * SSM
 * RDS
 * Redis Cluster
-* OpsWorks
+* EC2 Autoscaling
 * Cloudfront with Lambda@Edge
 * and may more features
 
@@ -25,7 +25,7 @@ This stands up the www.data.qld.gov.au and www.publications.qld.gov.au aws stack
 For the system to work with updates to the lambda function, you must;
 * first add a new version to cloudfront-lambdaAtEdge.cfn.yml which references the changed lambda function (there is no need for a new lambda function)
 * export the new version from said cloudformation template
-* update the cloudfront.yml ansible script to load the new version property name. 
+* update the cloudfront.yml ansible script to load the new version property name.
 * you can delete previous versions after a successful real, do note that cloudfront will hold onto a lambda function and versions until its 'replication' finishes.
 
 **QOL 2019 update**
@@ -60,7 +60,7 @@ Common issues during set up are as follows:
 
 It's assumed that you:
 
-* have a pretty good working knowledge of AWS, CloudFormation, OpsWorks, and CKAN and its requirements such as Solr and Postgres. Those will be necessary to troubleshoot builds when you haven't provided the correct parameters or some other obstacle gets in your way.
+* have a pretty good working knowledge of AWS, CloudFormation, EC2 Autoscaling, and CKAN and its requirements such as Solr and Postgres. Those will be necessary to troubleshoot builds when you haven't provided the correct parameters or some other obstacle gets in your way.
 * have built, installed and successfully run CKAN manually on some kind of single node configuration. If not, this stack isn't designed to be something to cut your teeth on. It's been designed to be relatively foolproof, but not completely so.
 * know your way around the Linux command line reasonably well and know how to deal with error logs, dependency conflicts etc.
 
@@ -118,7 +118,7 @@ and automated system maintenance.
 
 Our hope and expectation is that it benefits the wider Public Data community and progresses the Open Data ideal.
 
-Current AWS costs for 2 CKAN applications by 4 envirionments is just shy of 3k USD a month. 
+Current AWS costs for 2 CKAN applications by 4 environments is just shy of 3k USD a month.
 
 ## TODO ##
 Make requirements-dev look up vars/shared-${app}.var.yml and test all environment plugins

--- a/templates/Datashades-OpsWorks-CKAN-Extensions.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Extensions.cfn.yml.j2
@@ -1,10 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: |-
-  Creates OpsWorks Applications for CKAN Stack extensions.
-  Current extension list:
-  Legacy theme
-  Queensland Government extension
+Description: Creates metadata needed to deploy CKAN Stack extensions.
 
 Parameters:
   Environment:

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Creates instances for OpsWorks CKAN NFS Stack.'
+Description: 'Creates server instances for a CKAN Stack.'
 
 Parameters:
   ApplicationName:

--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "Creates an OpsWorks CKAN Stack."
+Description: "Creates permissions and metadata for a CKAN stack."
 
 Parameters:
   CookbookURL:
@@ -84,13 +84,6 @@ Parameters:
     Type: String
     MinLength: 6
     MaxLength: 254
-  CreateServiceRole:
-    Description: Required if OpsWorks stacks have never been created in this account.
-    Type: String
-    Default: "no"
-    AllowedValues:
-      - "yes"
-      - "no"
   EnableDataStore:
     Description: Whether or not to support the DataStore.
     Type: String
@@ -152,42 +145,7 @@ Parameters:
     Description: Name of the S3 Attachment bucket.
     Type: String
 
-Conditions:
-  ProvisionServiceRole:
-    Fn::Equals:
-      - "yes"
-      - !Ref CreateServiceRole
-
 Resources:
-  OpsWorksServiceRole:
-    Condition: ProvisionServiceRole
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: Allow
-            Principal:
-              Service: opsworks.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: "aws-opsworks-service-policy"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              -
-                Action:
-                  - "ec2:*"
-                  - iam:PassRole
-                  - cloudwatch:GetMetricStatistics
-                  - cloudwatch:DescribeAlarms
-                  - "ecs:*"
-                  - "elasticloadbalancing:*"
-                  - "rds:*"
-                Effect: Allow
-                Resource: "*"
-
   AttachmentsPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -377,7 +335,6 @@ Resources:
         - !Ref InstancePolicy
         - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs
         - arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess # for domain name lookups
         - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy # to write CloudWatch logs
         - arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess # for domain name lookups
@@ -420,7 +377,6 @@ Resources:
         - !Ref AttachmentsPolicy
         - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs
         - arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess # for domain name lookups
         - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy # to write CloudWatch logs
         - arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess # for domain name lookups
@@ -569,194 +525,6 @@ Resources:
       Type: String
       Value: !Ref SolrSource
 
-  OpsWorksStack:
-    Type: AWS::OpsWorks::Stack
-    Properties:
-      AgentVersion: LATEST
-      ConfigurationManager:
-        Name: Chef
-        Version: 12
-      CustomCookbooksSource:
-        Revision: !Ref CookbookRevision
-        Type: !Ref CookbookURLType
-        # SshKey: !Sub "${CookbookSSHKey}\n"
-        Url: !Ref CookbookURL
-      DefaultInstanceProfileArn:
-        Fn::GetAtt:
-          - InstanceRoleProfile
-          - Arn
-      DefaultOs: "Amazon Linux 2"
-      DefaultSshKeyName: !Ref DefaultEC2Key
-      DefaultSubnetId:
-        Fn::ImportValue: !Sub "${AppSubnets}A"
-      Name: !Sub "${ApplicationName}_${Environment}"
-      ServiceRoleArn:
-        Fn::If:
-          - ProvisionServiceRole
-          - Fn::GetAtt:
-            - OpsWorksServiceRole
-            - Arn
-          - Fn::Join:
-            - ""
-            - - "arn:aws:iam::"
-              - !Ref "AWS::AccountId"
-              - ":role/aws-opsworks-service-role"
-      UseCustomCookbooks: true
-      UseOpsworksSecurityGroups: false
-      VpcId:
-        Fn::ImportValue: !Ref StackVPC
-
-  OpsWorksSolrLayer:
-    Type: AWS::OpsWorks::Layer
-    Properties:
-      CustomRecipes:
-        Setup:
-          - "datashades::solr-setup"
-        Deploy:
-          - "datashades::solr-deploy"
-        Configure:
-          - "datashades::solr-configure"
-      AutoAssignElasticIps: false
-      AutoAssignPublicIps: false
-      CustomSecurityGroupIds:
-        - Fn::ImportValue: !Ref AdminSG
-        - Fn::ImportValue: !Ref DatabaseSG
-      EnableAutoHealing: true
-      InstallUpdatesOnBoot: true
-      Name: !Sub "${ApplicationName}-Solr"
-      Shortname: !Sub "${ApplicationId}-solr"
-      StackId: !Ref OpsWorksStack
-      Type: custom
-      Tags:
-        - Key: Layer
-          Value: solr
-      VolumeConfigurations:
-        - MountPoint: "/mnt/local_data"
-          NumberOfDisks: 1
-          Size: 32
-
-  OpsWorksWebLayer:
-    Type: AWS::OpsWorks::Layer
-    Properties:
-      AutoAssignElasticIps: false
-      AutoAssignPublicIps: false
-      CustomRecipes:
-        Setup:
-          - "datashades::ckanweb-setup"
-        Deploy:
-          - "datashades::ckanweb-deploy"
-        Configure:
-          - "datashades::ckanweb-configure"
-      CustomSecurityGroupIds:
-        - Fn::ImportValue: !Ref AdminSG
-        - Fn::ImportValue: !Ref AppSG
-      CustomInstanceProfileArn:
-        Fn::GetAtt:
-          - WebInstanceRoleProfile
-          - Arn
-      EnableAutoHealing: true
-      InstallUpdatesOnBoot: true
-      Name: !Sub "${ApplicationName}-Web"
-      Shortname: !Sub "${ApplicationId}-web"
-      StackId: !Ref OpsWorksStack
-      Type: custom
-      Tags:
-        - Key: Layer
-          Value: web
-      LoadBasedAutoScaling:
-        Enable: Yes
-        UpScaling:
-          CpuThreshold: 80
-          MemoryThreshold: 80
-          IgnoreMetricsTime: 20
-          InstanceCount: 1
-          ThresholdsWaitTime: 5
-        DownScaling:
-          CpuThreshold: 30
-          MemoryThreshold: 30
-          IgnoreMetricsTime: 20
-          InstanceCount: 1
-          ThresholdsWaitTime: 10
-      VolumeConfigurations:
-        - MountPoint: "/mnt/local_data"
-          NumberOfDisks: 1
-          Size: 32
-
-  OpsWorksBatchLayer:
-    Type: AWS::OpsWorks::Layer
-    Properties:
-      AutoAssignElasticIps: false
-      AutoAssignPublicIps: false
-      CustomRecipes:
-        Setup:
-          - "datashades::ckanbatch-setup"
-        Deploy:
-          - "datashades::ckanbatch-deploy"
-        Configure:
-          - "datashades::ckanbatch-configure"
-      CustomSecurityGroupIds:
-        - Fn::ImportValue: !Ref AdminSG
-        - Fn::ImportValue: !Ref AppSG
-      CustomInstanceProfileArn:
-        Fn::GetAtt:
-          - WebInstanceRoleProfile
-          - Arn
-      EnableAutoHealing: true
-      InstallUpdatesOnBoot: true
-      Name: !Sub "${ApplicationName}-Batch"
-      Shortname: !Sub "${ApplicationId}-batch"
-      StackId: !Ref OpsWorksStack
-      Type: custom
-      Tags:
-        - Key: Layer
-          Value: batch
-      LoadBasedAutoScaling:
-        Enable: Yes
-        UpScaling:
-          CpuThreshold: 80
-          IgnoreMetricsTime: 20
-          InstanceCount: 1
-          ThresholdsWaitTime: 5
-        DownScaling:
-          CpuThreshold: 30
-          IgnoreMetricsTime: 20
-          InstanceCount: 1
-          ThresholdsWaitTime: 10
-      VolumeConfigurations:
-        - MountPoint: "/mnt/local_data"
-          NumberOfDisks: 1
-          Size: 32
-
-  CKANELB:
-    Type: AWS::ElasticLoadBalancing::LoadBalancer
-    Properties:
-      LoadBalancerName: !Sub "${Environment}-${ApplicationName}ELB"
-      CrossZone: true
-      HealthCheck:
-        Target: "HTTP:80/api/action/status_show"
-        HealthyThreshold: 2
-        UnhealthyThreshold: 6
-        Interval: 30
-        Timeout: 20
-      Listeners:
-        - LoadBalancerPort: 443
-          InstancePort: 80
-          Protocol: HTTPS
-          SSLCertificateId: !Ref ACMCertificateARN
-          PolicyNames:
-            - sticky-LB-1hour
-      LBCookieStickinessPolicy:
-        - PolicyName: sticky-LB-1hour
-          CookieExpirationPeriod: 3600
-      Scheme: "internet-facing"
-      SecurityGroups:
-        - Fn::ImportValue: !Ref AppLBSG
-        - Fn::ImportValue: !Ref CloudFrontSG
-      Subnets:
-        - Fn::ImportValue: !Sub "${WebSubnets}A"
-        - Fn::ImportValue: !Sub "${WebSubnets}B"
-        - Fn::ImportValue: !Sub "${WebSubnets}C"
-
   # Application Load Balancer structure is more complex than classic.
   # The LoadBalancer defines configuration values like logging config and security groups.
   # The Listener is external-facing, defining the port, certificate, etc,
@@ -824,12 +592,6 @@ Resources:
       VpcId:
         Fn::ImportValue: !Ref StackVPC
 
-  ELBAttachment:
-    Type: AWS::OpsWorks::ElasticLoadBalancerAttachment
-    Properties:
-      ElasticLoadBalancerName: !Ref CKANELB
-      LayerId: !Ref OpsWorksWebLayer
-
   WebELBDNSName:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -841,35 +603,6 @@ Resources:
         DNSName: !GetAtt CKANALB.DNSName
 
 Outputs:
-  StackID:
-    Value: !Ref OpsWorksStack
-    Description: OpsWorks Stack Id
-    Export:
-      Name: !Sub "${Environment}${ApplicationName}OpsWorksStack"
-
-  SolrLayer:
-    Value: !Ref OpsWorksSolrLayer
-    Description: SolrCloud Layer Id
-    Export:
-      Name: !Sub "${Environment}${ApplicationName}OpsWorksSolrLayer"
-
-  WebLayer:
-    Value: !Ref OpsWorksWebLayer
-    Description: Web Layer Id
-    Export:
-      Name: !Sub "${Environment}${ApplicationName}OpsWorksWebLayer"
-
-  BatchLayer:
-    Value: !Ref OpsWorksBatchLayer
-    Description: Batch Layer Id
-    Export:
-      Name: !Sub "${Environment}${ApplicationName}OpsWorksBatchLayer"
-
-  WebELBName:
-    Value: !Ref CKANELB
-    Export:
-      Name: !Sub "${Environment}${ApplicationName}WebElbName"
-
   WebELBDNSName:
     Value: !Ref WebELBDNSName
     Export:

--- a/templates/hosted-zone.cfn.yml
+++ b/templates/hosted-zone.cfn.yml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "Creates a private hosted zone to hold an OpsWorks CKAN Stack."
+Description: Creates metadata needed to deploy CKAN Stack extensions.
 
 Parameters:
   Environment:

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -37,7 +37,6 @@ common_stack: &common_stack
     CloudFrontSG: "{{ Environment }}CKANCloudfrontHTTPSSG"
     AppSG: "{{ Environment }}CKANAppAsgSG"
     DatabaseSG: "{{ Environment }}CKANDatabaseSG"
-    CreateServiceRole: "yes"
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"


### PR DESCRIPTION
- Can't rename CloudFormation stacks at this point, or else they will be deleted and recreated, which would be unnecessarily disruptive