### PR TITLE
QOLDEV-867 make deployments handle autoscaling more robustly

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -38,6 +38,8 @@ run-shared-resource-playbooks () {
 run-deployment () {
   run-playbook "chef-json"
   ./chef-deploy.sh datashades::ckanweb-setup,datashades::ckanweb-deploy,datashades::ckanweb-configure $INSTANCE_NAME $ENVIRONMENT web & WEB_PID=$!
+  # Check if the web deployment immediately failed
+  kill -0 $WEB_PID
   PARALLEL=1 ./chef-deploy.sh datashades::ckanbatch-setup,datashades::ckanbatch-deploy,datashades::ckanbatch-configure $INSTANCE_NAME $ENVIRONMENT batch & BATCH_PID=$!
   wait $WEB_PID
   wait $BATCH_PID

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -164,8 +164,7 @@ deploy () {
         debug "Deregistered instance $instance from load balancer $ELB_NAME, resulting registered instances: $OUTPUT"
       fi
       DEPLOYMENT_ID=$(aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --instance-ids $instance --parameters '{'"$CHEF_SOURCE"',"RunList":["'"$RUN_LIST"'"],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["14"],"ChefClientArguments":[""],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" --region ap-southeast-2 --query "Command.CommandId" --output text)
-      wait_for_deployment $DEPLOYMENT_ID
-      DEPLOYMENT_SUCCESS=$?
+      wait_for_deployment $DEPLOYMENT_ID || DEPLOYMENT_SUCCESS=$?
       if [ "$ASG_NAME" != "" ]; then
         OUTPUT=$(aws autoscaling exit-standby --auto-scaling-group-name "$ASG_NAME" --instance-ids $instance --query "Activities[].Description" --output text)
         debug "$OUTPUT"

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -152,6 +152,7 @@ deploy () {
         CAPACITY_1=`echo $CAPACITIES | awk '{print $1}'`
         CAPACITY_2=`echo $CAPACITIES | awk '{print $2}'`
         if [ "$CAPACITY_1" = "$CAPACITY_2" ]; then
+          debug "Capacity is at minimum ($CAPACITY_1 = $CAPACITY_2), new instance will be started"
           DECREMENT_BEHAVIOUR="--no-should-decrement-desired-capacity"
         else
           DECREMENT_BEHAVIOUR="--should-decrement-desired-capacity"

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -148,7 +148,7 @@ deploy () {
       if [ "$INSTANCE_STATE" != "running" ]; then continue; fi
       if [ "$ASG_NAME" != "" ] && (aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name $ASG_NAME --query "AutoScalingGroups[0].Instances[?InstanceId=='$instance'].InstanceId" --output text |grep "$instance" >/dev/null); then
         # Check if the group is already at minimum capacity
-        CAPACITIES=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name TRAINING-CKANTest-Web-ASG --query "AutoScalingGroups[0].{min: MinSize, desired: DesiredCapacity}" --output text)
+        CAPACITIES=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name $ASG_NAME --query "AutoScalingGroups[0].{min: MinSize, desired: DesiredCapacity}" --output text)
         CAPACITY_1=`echo $CAPACITIES | awk '{print $1}'`
         CAPACITY_2=`echo $CAPACITIES | awk '{print $2}'`
         if [ "$CAPACITY_1" = "$CAPACITY_2" ]; then

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -164,6 +164,7 @@ deploy () {
         debug "Deregistered instance $instance from load balancer $ELB_NAME, resulting registered instances: $OUTPUT"
       fi
       DEPLOYMENT_ID=$(aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --instance-ids $instance --parameters '{'"$CHEF_SOURCE"',"RunList":["'"$RUN_LIST"'"],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["14"],"ChefClientArguments":[""],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" --region ap-southeast-2 --query "Command.CommandId" --output text)
+      DEPLOYMENT_SUCCESS=0
       wait_for_deployment $DEPLOYMENT_ID || DEPLOYMENT_SUCCESS=$?
       if [ "$ASG_NAME" != "" ]; then
         OUTPUT=$(aws autoscaling exit-standby --auto-scaling-group-name "$ASG_NAME" --instance-ids $instance --query "Activities[].Description" --output text)

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -182,18 +182,12 @@ Resources:
               fi
               aws lambda invoke $REGION --function-name "$FUNCTION_NAME" $PAYLOAD_FORMAT --payload '{"EC2InstanceId": "'$INSTANCE_ID'", "phase": "setup"}' /var/log/instance-setup.log.`date '+%s'`
 
-{% if layer == 'Web' %}
-{% set minInstanceCount = (item.template_parameters['WebEC2Count'] | default('2') | int) - 1 %}
-{% else %}
-{% set minInstanceCount = 1 %}
-{% endif %}
-
   {{ layer }}ScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       AutoScalingGroupName: !Sub "${Environment}-${ApplicationName}-{{ layer }}-ASG"
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: {{ minInstanceCount }}
+      MinSize: !Ref {{ layer }}EC2Count
       MaxSize: 6
       LaunchTemplate:
         LaunchTemplateId: !Ref {{ layer }}LaunchTemplate
@@ -244,7 +238,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Ref {{ layer }}ScalingGroup
       DesiredCapacity: !Ref {{ layer }}EC2Count
-      MinSize: {{ minInstanceCount }}
+      MinSize: !Ref {{ layer }}EC2Count
       MaxSize: 6
       Recurrence: "0 20 * * *"
 {% endif %}

--- a/vars/instances-CKANTest.var.yml
+++ b/vars/instances-CKANTest.var.yml
@@ -24,7 +24,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      WebEC2Count: 2
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"
@@ -34,7 +33,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      WebEC2Count: 2
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"

--- a/vars/instances-OpenData.var.yml
+++ b/vars/instances-OpenData.var.yml
@@ -27,7 +27,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       Environment: PROD
       SolrEC2Size: t3a.medium
-      WebEC2Count: 5 #We have been running on 2 auto and 3 manually created instances, time to make it IasC
+      WebEC2Count: 5
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"
@@ -37,7 +37,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      WebEC2Count: 2
       SolrEC2Size: t3a.medium
     tags:
       <<: *common_stack_tags

--- a/vars/instances-Publications.var.yml
+++ b/vars/instances-Publications.var.yml
@@ -25,7 +25,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      WebEC2Count: 2
       SolrEC2Size: t3a.small
       WebEC2Size: t3a.small
       BatchEC2Size: t3a.micro
@@ -38,7 +37,6 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      WebEC2Count: 2
       SolrEC2Size: t3a.small
       WebEC2Size: t3a.small
       BatchEC2Size: t3a.micro


### PR DESCRIPTION
- If current capacity is at the minimum, then don't reduce it further when putting an instance in standby.
- Increase minimum capacity configuration to reflect new behaviour.