### PR TITLE
[QOLDEV-908] move WAF stack to global region

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -602,6 +602,13 @@ Resources:
         HostedZoneId: !GetAtt CKANALB.CanonicalHostedZoneID
         DNSName: !GetAtt CKANALB.DNSName
 
+  WebELBDNSNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/web_loadbalancer_dns_name"
+      Type: String
+      Value: !GetAtt CKANALB.DNSName
+
 Outputs:
   WebELBDNSName:
     Value: !Ref WebELBDNSName

--- a/templates/cloudfront.cfn.yml.j2
+++ b/templates/cloudfront.cfn.yml.j2
@@ -379,8 +379,7 @@ Resources:
           S3OriginConfig:
             OriginAccessIdentity: ""
         PriceClass: PriceClass_All
-        WebACLId:
-          Fn::ImportValue: !Ref WebACLId
+        WebACLId: !Ref WebACLId
         HttpVersion: 'http2and3'
         IPV6Enabled: 'true'
         ViewerCertificate:

--- a/templates/cloudfront.cfn.yml.j2
+++ b/templates/cloudfront.cfn.yml.j2
@@ -356,8 +356,7 @@ Resources:
           Prefix: !Sub "cloudfront-logs/${Platform}/${Environment}/"
 
         Origins:
-        - DomainName:
-            Fn::ImportValue: !Ref WebOrigin
+        - DomainName: !Ref WebOrigin
           Id: 'WebOrigin'
           CustomOriginConfig:
             OriginProtocolPolicy: "match-viewer"      # required, accepts http-only, match-viewer, https-only

--- a/templates/waf_web_acl.cfn.yml
+++ b/templates/waf_web_acl.cfn.yml
@@ -48,6 +48,13 @@ Resources:
           Negated: false
           Type: "XssMatch"
 
+  WAFWebACLIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/common/waf_acl_id"
+      Type: String
+      Value: !Ref WebACL
+
 Outputs:
   WebACLId:
     Value:

--- a/templates/waf_web_acl.cfn.yml
+++ b/templates/waf_web_acl.cfn.yml
@@ -8,6 +8,35 @@ Parameters:
     Type: String
     Default: CKAN
 Resources:
+  WebACLv2:
+    Type: "AWS::WAFv2::WebACL"
+    Properties:
+      Name: !Sub "${Environment}-${Platform}-WebACLv2"
+      Description: !Sub "${Environment} ${Platform} WAFv2 Web ACL to block traffic based on defined rules."
+      Scope: CLOUDFRONT
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: "WafWebACL"
+        SampledRequestsEnabled: true
+      Rules:
+        - Name: !Sub "${Environment}-${Platform}-XSSRule"
+          Priority: 1
+          Action:
+            Block: {}
+          Statement:
+            XssMatchStatement:
+              FieldToMatch:
+                UriPath: {}
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: "XSSRule"
+            SampledRequestsEnabled: true
+
   WebACL:
     Type: "AWS::WAF::WebACL"
     Properties:
@@ -53,7 +82,7 @@ Resources:
     Properties:
       Name: !Sub "/config/CKAN/${Environment}/common/waf_acl_id"
       Type: String
-      Value: !Ref WebACL
+      Value: !GetAtt WebACLv2.Arn
 
 Outputs:
   WebACLId:

--- a/vars/cloudfront.var.yml
+++ b/vars/cloudfront.var.yml
@@ -11,7 +11,7 @@ cloudformation_stacks:
     template_jinja: "{{ template }}.j2"
     template_parameters:
       OriginReadTimeout: 180 #service increase requested, we now have 3 min wait available
-      WebOrigin: "{{ service_name_lower }}.{{ RootDomain }}"
+      WebOrigin: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/web_loadbalancer_dns_name') }}"
       CmsOrigin: "{{ CmsOrigin }}"
       WebACLId: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/common/waf_acl_id', region='us-east-1') }}"
       Environment: "{{ Environment }}"

--- a/vars/cloudfront.var.yml
+++ b/vars/cloudfront.var.yml
@@ -5,7 +5,7 @@ cloudformation_stacks:
   - name: "{{ service_name }}-{{ Environment }}-CLOUDFRONT"
     cloudformation_waf: "CKAN-{{ Environment }}-WAF"
     state: "{{ state | default('present')}}"
-    region: "us-east-1"
+    region: "{{ region }}"
     disable_rollback: 'true'
     template: "{{ template }}"
     template_jinja: "{{ template }}.j2"
@@ -13,7 +13,7 @@ cloudformation_stacks:
       OriginReadTimeout: 180 #service increase requested, we now have 3 min wait available
       WebOrigin: "{{ service_name_lower }}.{{ RootDomain }}"
       CmsOrigin: "{{ CmsOrigin }}"
-      WebACLId: "{{ Environment }}CKANWebACLId"
+      WebACLId: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/common/waf_acl_id', region='us-east-1') }}"
       Environment: "{{ Environment }}"
       Platform: "{{ service_name }}"
       ACMCertificateARN: "{{ ACMCertificateARNForUsEast1 }}"

--- a/vars/cloudfront.var.yml
+++ b/vars/cloudfront.var.yml
@@ -5,7 +5,7 @@ cloudformation_stacks:
   - name: "{{ service_name }}-{{ Environment }}-CLOUDFRONT"
     cloudformation_waf: "CKAN-{{ Environment }}-WAF"
     state: "{{ state | default('present')}}"
-    region: "{{ region }}"
+    region: "us-east-1"
     disable_rollback: 'true'
     template: "{{ template }}"
     template_jinja: "{{ template }}.j2"

--- a/vars/cloudfront.var.yml
+++ b/vars/cloudfront.var.yml
@@ -11,7 +11,7 @@ cloudformation_stacks:
     template_jinja: "{{ template }}.j2"
     template_parameters:
       OriginReadTimeout: 180 #service increase requested, we now have 3 min wait available
-      WebOrigin: "{{ Environment }}{{ service_name }}WebElbDNSName"
+      WebOrigin: "{{ service_name_lower }}.{{ RootDomain }}"
       CmsOrigin: "{{ CmsOrigin }}"
       WebACLId: "{{ Environment }}CKANWebACLId"
       Environment: "{{ Environment }}"

--- a/vars/waf_web_acl.var.yml
+++ b/vars/waf_web_acl.var.yml
@@ -2,7 +2,7 @@
 cloudformation_stacks:
   - name: "CKAN-{{ Environment }}-WAF"
     state: "{{ state | default('present')}}"
-    region: "{{ region }}"
+    region: "us-east-1"
     disable_rollback: 'true'
     template: "templates/waf_web_acl.cfn.yml"
     template_parameters:


### PR DESCRIPTION
- WAFv2 resources are required to be in the us-east-1 region, but CloudFormation exports cannot cross regions, so use the SSM Parameter Store to pass necessary values.
