### PR TITLE
[QOLSVC-6752] update CKAN core to reduce datastore deadlocks

### DIFF
--- a/files/instanceSetupLambda.js
+++ b/files/instanceSetupLambda.js
@@ -104,6 +104,7 @@ exports.handler = async (event) => {
   }
 
   await ssm.send(new SendCommandCommand({
+    Comment: `Running '${deployPhase}' on ${service} ${environment} instance ${instanceId}`,
     DocumentName: "AWS-ApplyChefRecipes",
     DocumentVersion: '\$DEFAULT',
     InstanceIds: [ instanceId ],

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -5,7 +5,7 @@ NonProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdNonProduction'
 ProductionAnalyticsId: "{{ lookup('aws_ssm', '/config/CKAN/GaIdProduction', region=region) }}"
 
 solr_url: "https://archive.apache.org/dist/lucene/solr/8.11.2/solr-8.11.2.zip"
-ckan_tag: "ckan-2.10.4-qgov.3"
+ckan_tag: "ckan-2.10.4-qgov.4"
 ckan_qgov_branch: "qgov-master-2.10.4"
 
 common_stack: &common_stack


### PR DESCRIPTION
- Limit datastore_delete to waiting 20 seconds for a lock to drop the table. The actual drop can take longer, but if we can't acquire a lock in a timely manner, we should avoid deadlock by cancelling