### PR TITLE
[QOLDEV-920] replace instances with obsolete launch templates during deployment

### DIFF
--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -115,8 +115,6 @@ deploy () {
   if [ "$LAYER_NAME" != "" ]; then
       INSTANCE_IDENTIFIER_SNIPPET="${INSTANCE_IDENTIFIER_SNIPPET} Name=tag:Layer,Values=$LAYER_NAME"
   fi
-  ELB_NAME=$(find_load_balancer)
-  debug "Classic load balancer: $ELB_NAME"
   ALB_NAME=$(find_load_balancer_v2)
   debug "Application load balancer: $ALB_NAME"
   if [ "$ALB_NAME" != "" ]; then
@@ -177,9 +175,6 @@ deploy () {
         # Instances in standby will not get traffic nor health checks, allowing us to update them without interruption
         OUTPUT=$(aws autoscaling enter-standby --auto-scaling-group-name "$ASG_NAME" $DECREMENT_BEHAVIOUR --instance-ids $instance --query "Activities[].Description" --output text)
         debug "$OUTPUT"
-      elif [ "$ELB_NAME" != "" ]; then
-        OUTPUT=$(aws elb deregister-instances-from-load-balancer --load-balancer-name "$ELB_NAME" --instances "$instance" --query "Instances[].InstanceId" --output text)
-        debug "Deregistered instance $instance from load balancer $ELB_NAME, resulting registered instances: $OUTPUT"
       fi
       DEPLOYMENT_ID=$(aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --instance-ids $instance --parameters '{'"$CHEF_SOURCE"',"RunList":["'"$RUN_LIST"'"],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["14"],"ChefClientArguments":[""],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" --region ap-southeast-2 --query "Command.CommandId" --output text)
       DEPLOYMENT_SUCCESS=0
@@ -190,9 +185,6 @@ deploy () {
         # but leave it in standby.
         OUTPUT=$(aws autoscaling exit-standby --auto-scaling-group-name "$ASG_NAME" --instance-ids $instance --query "Activities[].Description" --output text)
         debug "$OUTPUT"
-      elif [ "$ELB_NAME" != "" ]; then
-        OUTPUT=$(aws elb register-instances-with-load-balancer --load-balancer-name "$ELB_NAME" --instances "$instance" --query "Instances[].InstanceId" --output text)
-        debug "Registered instance with load balancer $ELB_NAME, resulting registered instances: $OUTPUT"
       fi
       if [ "$DEPLOYMENT_SUCCESS" != "0" ]; then return 1; fi
     done

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -133,8 +133,14 @@ deploy () {
     debug "Target instance(s) matching '$INSTANCE_IDENTIFIER_SNIPPET': $INSTANCE_IDS"
   fi
   if [ "$ASG_NAME" != "" ]; then
-    # if any instance is based on an obsolete launch template, launch an instance refresh
     debug "Target autoscaling group: $ASG_NAME"
+
+    # CloudFormation does not automatically replace existing instances
+    # when an ASG is updated to point to a new launch template.
+    # This gives the end user flexibility in how that replacement occurs.
+    #
+    # If any instance is based on an obsolete launch template,
+    # launch an instance refresh instead of a Chef deployment.
     ASG_TEMPLATE_VERSION=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-name $ASG_NAME --query "AutoScalingGroups[0].LaunchTemplate.Version" --output text)
     INSTANCE_TEMPLATE_VERSIONS=$(aws autoscaling describe-auto-scaling-instances --instance-ids $INSTANCE_IDS --query "AutoScalingInstances[].LaunchTemplate.Version" --output text)
     for instance_version in $INSTANCE_TEMPLATE_VERSIONS; do


### PR DESCRIPTION
- If any instance is on the wrong launch template version, run an instance refresh instead of a regular deployment.
- TODO Use SkipMatching flag to reduce the refresh scope once Bamboo is on newer AWS CLI