### PR TITLE
[QOLSVC-7171] include DB version in RDS parameter group name

### DIFF
--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -173,7 +173,7 @@ Resources:
   DBParameters:
     Type: AWS::RDS::DBParameterGroup
     Properties:
-      DBParameterGroupName: !Sub "${Environment}DatabaseParameters"
+      DBParameterGroupName: !Sub "${Environment}-${DBEngine}${DBEngineVersion}-DatabaseParameters"
       Description: Setup parameters for Queensland Government databases
       Family: !Sub "${DBEngine}${DBEngineVersion}"
       Parameters:


### PR DESCRIPTION
- Names must be unique, so when upgrading the major database version, which creates the new database before deleting the old, we need to use a different name