### PR TITLE
[QOLDEV-933] add SSM Parameter Store entry for PURL endpoint

### DIFF
--- a/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Stack.cfn.yml.j2
@@ -144,6 +144,9 @@ Parameters:
   AttachmentsBucketName:
     Description: Name of the S3 Attachment bucket.
     Type: String
+  PurlEndpoint:
+    Description: Endpoint to contact for URL lookups.
+    Type: String
 
 Resources:
   AttachmentsPolicy:
@@ -524,6 +527,13 @@ Resources:
       Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/solr_app/app_source/url"
       Type: String
       Value: !Ref SolrSource
+
+  PURLEndpointParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/config/CKAN/${Environment}/app/${ApplicationId}/purl_endpoint"
+      Type: String
+      Value: !Ref PurlEndpoint
 
   # Application Load Balancer structure is more complex than classic.
   # The LoadBalancer defines configuration values like logging config and security groups.

--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -44,6 +44,7 @@ common_stack: &common_stack
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr_url }}"
+    PurlEndpoint: "https://test.smartservice.qld.gov.au/services/url/translate/v3.json?sourceurl={source}"
   tags: &common_stack_tags
     Environment: "{{ Environment }}"
     Service: "{{ service_name }}"
@@ -59,6 +60,7 @@ cloudformation_stacks:
       Environment: PROD
       GTMContainerId: "{{ ProductionGTMId }}"
       AnalyticsId: "{{ ProductionAnalyticsId }}"
+      PurlEndpoint: "https://www.smartservice.qld.gov.au/services/url/translate/v3.json?sourceurl={source}"
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"


### PR DESCRIPTION
- Currently we use a config file that tries to provide a mapping for every environment based on hostname, which is inelegant and fragile.