### PR TITLE
[QOLSVC-7171] disable database SSL requirement

### DIFF
--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -179,3 +179,4 @@ Resources:
       Parameters:
         datestyle: "ISO, DMY"
         rds.adaptive_autovacuum: 1
+        rds.force_ssl: 0


### PR DESCRIPTION
- Our Chef runs don't currently handle SSL connections to the database.
- PostgreSQL 15+ forces SSL by default.