### PR TITLE
FIX: QOLDEV-989 fix max_parallel_workers_per_gather to 0 when vCPU less than 4

### DIFF
--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -27,6 +27,7 @@ Outputs:
     Value: !Ref Database
     Description: RDS Instance Id
 
+
 Parameters:
   DBAllocatedStorage:
     ConstraintDescription: must be between 5 and 1024Gb.
@@ -46,6 +47,13 @@ Parameters:
     ConstraintDescription: must select a valid database instance type.
     Description: Database instance class
     Type: String
+  DBMaxParallelWorkersPerGather:
+    Type: Number
+    Default: -1
+    Description: "Specify the max parallel workers per gather (0 - 100), or -1 for no setting."
+    MinValue: -1
+    MaxValue: 100
+
   DBName:
     AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
     ConstraintDescription: must begin with a letter and contain only 1-64 alphanumeric
@@ -116,6 +124,8 @@ Parameters:
   StackZone:
     Description: Exported name of the Route53 hosted zone ID.
     Type: String
+Conditions:
+  IsMaxParallelWorkersPerGatherSet: !Not [!Equals [!Ref DBMaxParallelWorkersPerGather, "-1"]]
 
 Resources:
   Database:
@@ -177,6 +187,14 @@ Resources:
       Description: Setup parameters for Queensland Government databases
       Family: !Sub "${DBEngine}${DBEngineVersion}"
       Parameters:
-        datestyle: "ISO, DMY"
-        rds.adaptive_autovacuum: 1
-        rds.force_ssl: 0
+        Fn::If:
+          - IsMaxParallelWorkersPerGatherSet
+          - datestyle: "ISO, DMY"
+            rds.adaptive_autovacuum: 1
+            rds.force_ssl: 0
+            max_parallel_workers_per_gather: !Ref DBMaxParallelWorkersPerGather
+          #ELSE
+          - datestyle: "ISO, DMY"
+            rds.adaptive_autovacuum: 1
+            rds.force_ssl: 0
+

--- a/vars/database.var.yml
+++ b/vars/database.var.yml
@@ -32,6 +32,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "600"
       DBClass: db.m5.large
+      DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "True"
       PreferredMaintenanceWindow: "sat:17:00-sat:17:30"
       Environment: PROD
@@ -46,6 +47,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: '300'
       DBClass: db.t3.large
+      DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "True"
       Environment: STAGING
       MultiAZ: "true"
@@ -59,6 +61,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "100"
       DBClass: db.t3.medium
+      DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "False"
       Environment: TRAINING
       MultiAZ: "false"
@@ -73,6 +76,7 @@ cloudformation_stacks:
       DBEngineVersion: 15
       DBAllocatedStorage: "200"
       DBClass: db.t3.medium
+      DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "False"
       Environment: DEV
       MultiAZ: "false"


### PR DESCRIPTION
[fix: QOLDEV-989 disable Parallel Workers Per Gather when vCPU is less than 4](https://github.com/qld-gov-au/ckan-qld-infrastructure/commit/cbe76985999b67f272464765413aa283600d9fc3) 

To stop IPC: MessageQueueSend waits on:

SELECT activity.id AS activity_id, activity.timestamp AS activity_timestamp, activity.user_id AS activity_user_id, activity.object_id AS activity_object_id, activity.revision_id AS activity_revision_id, activity.activity_type AS activity_activity_type
FROM activity
WHERE activity.object_id IN (SELECT package.id
FROM package
WHERE package.private = false AND package.owner_org = '1d443ba7-8efb-42f0-b836-9be70390378d' UNION SELECT '1d443ba7-8efb-42f0-b836-9be70390378d' AS anon_1) AND (activity.user_id NOT IN ('cefefdab-2536-436b-b34c-75252b2e2c0e')) ORDER BY activity.timestamp DESC
 LIMIT 32