### PR TITLE
QOLDEV-833 improve autoscaling AMI handling

### DIFF
--- a/create-AMI.yml
+++ b/create-AMI.yml
@@ -95,9 +95,10 @@
           Name: "{{ InstanceName }}-{{ timestamp | replace(':', '-') }}"
           Environment: "{{ Environment }}"
           Service: "{{ service_name }}"
+          Layer: "{{ layer | lower }}"
           Division: "{{ Division }}"
           Owner: "{{ Owner }}"
-          Version: "1.0"
+          Version: "{{ image_version | default('1.0') }}"
       register: new_image
 
     - name: Record AMI ID

--- a/create-AMI.yml
+++ b/create-AMI.yml
@@ -103,4 +103,4 @@
 
     - name: Record AMI ID
       shell: |
-        aws ssm put-parameter --type String --name "/config/CKAN/{{ Environment }}/app/{{ service_name_lower }}/{{ layer }}AmiId" --value "{{ new_image.image_id }}"
+        aws ssm put-parameter --overwrite --type String --name "/config/CKAN/{{ Environment }}/app/{{ service_name_lower }}/{{ layer }}AmiId" --value "{{ new_image.image_id }}"


### PR DESCRIPTION
- Fix SSM parameter so baseline AMIs can be automatically updated
- Allow deployments to recognise when an AMI already exists and doesn't need to be generated.