### PR TITLE
QOLSVC-8437 fix mobile navigation menu position

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -70,7 +70,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.3.0"
+      version: "7.3.1"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -70,7 +70,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.3.0"
+      version: "7.3.1"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -38,7 +38,7 @@ extensions:
       type: "git"
       description: "CKAN Extension for Queensland Government Publications theme"
       url: "https://github.com/qld-gov-au/ckanext-publications-qld-theme.git"
-      version: "1.4.5"
+      version: "1.4.6"
 
     CKANExtResourceTypeValidation: &CKANExtResourceTypeValidation
       name: "ckanext-resource-type-validation-{{ Environment }}"


### PR DESCRIPTION
CKAN 2.10 added a class to the main 'div' tag, which was not reflected in our themes, resulting in mobile navigation menus appearing above the content.