### PR TITLE
[QOLDEV-833] ensure existing image IDs are applied to the ASG when found

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -35,7 +35,7 @@ run-shared-resource-playbooks () {
 
 run-deployment () {
   run-playbook "chef-json"
-  ./chef-deploy.sh datashades::ckanweb-configure $INSTANCE_NAME $ENVIRONMENT web & WEB_PID=$!
+  PARALLEL=1 ./chef-deploy.sh datashades::ckanweb-configure $INSTANCE_NAME $ENVIRONMENT web & WEB_PID=$!
   # Check if the web deployment immediately failed
   kill -0 $WEB_PID
   PARALLEL=1 ./chef-deploy.sh datashades::ckanbatch-configure $INSTANCE_NAME $ENVIRONMENT batch & BATCH_PID=$!

--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -74,7 +74,8 @@ create-amis () {
   run-playbook "AMI-templates.yml"
   ANSIBLE_EXTRA_VARS="$ANSIBLE_EXTRA_VARS timestamp=`date -u +%Y-%m-%dT%H:%M:%SZ` image_version=$IMAGE_VERSION"
   for layer in Batch Web Solr; do
-    if [ "${layer}_IMAGE_ID" != "" ]; then
+    eval "image=\$${layer}_IMAGE_ID"
+    if [ "$image" = "" ]; then
       run-playbook "create-AMI" "layer=$layer" & eval "${layer}_PID=$!"
     fi
   done

--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -50,21 +50,40 @@ create-amis () {
   if [ "$IMAGE_VERSION" = "" ]; then
     IMAGE_VERSION=`git rev-parse HEAD` || true
   fi
-  if [ "$IMAGE_VERSION" != "" ]; then
-    echo "Checking for existing $ENVIRONMENT $INSTANCE_NAME images tagged with version ${IMAGE_VERSION}..."
-    IMAGE_IDS=$(aws ec2 describe-images --filters "Name=tag:Environment,Values=$ENVIRONMENT" "Name=tag:Service,Values=$INSTANCE_NAME" "Name=tag:Version,Values=$IMAGE_VERSION" --query "Images[].ImageId" --output text)
-    if [ "$IMAGE_IDS" != "" ]; then
-      echo "Found existing image(s): $IMAGE_IDS"
-      return 0
-    fi
+  if [ "$IMAGE_VERSION" = "" ]; then
+    AMI_NEEDED=1
+  else
+    for layer in Web Batch Solr; do
+      lowercase_layer=`echo $layer | tr '[:upper:]' '[:lower:]'`
+      echo "Checking for existing $ENVIRONMENT $INSTANCE_NAME $lowercase_layer image tagged with version ${IMAGE_VERSION}..."
+      IMAGE_ID=$(aws ec2 describe-images --filters "Name=tag:Environment,Values=$ENVIRONMENT" "Name=tag:Service,Values=$INSTANCE_NAME" "Name=tag:Version,Values=$IMAGE_VERSION" "Name=tag:Layer,Values=$lowercase_layer" --query "Images[].ImageId" --output text |tail -1 |tr -d '[:space:]')
+      if [ "$IMAGE_ID" = "" ]; then
+        AMI_NEEDED=1
+      else
+        echo "Found existing image(s): $IMAGE_ID"
+        aws ssm put-parameter --overwrite --type String --name "/config/CKAN/$ENVIRONMENT/app/$INSTANCE_SHORTNAME/${layer}AmiId" --value "$IMAGE_ID"
+        eval "${layer}_IMAGE_ID=$IMAGE_ID"
+      fi
+    done
   fi
+  if [ "$AMI_NEEDED" != "1" ]; then
+    echo "All machine images found, skipping generation"
+    return 0
+  fi
+  echo "Generating custom machine image(s)..."
   run-playbook "AMI-templates.yml"
   ANSIBLE_EXTRA_VARS="$ANSIBLE_EXTRA_VARS timestamp=`date -u +%Y-%m-%dT%H:%M:%SZ` image_version=$IMAGE_VERSION"
-  run-playbook "create-AMI" "layer=Batch" & BATCH_PID=$!
-  run-playbook "create-AMI" "layer=Web" & WEB_PID=$!
-  run-playbook "create-AMI" "layer=Solr"
-  wait $BATCH_PID
-  wait $WEB_PID
+  for layer in Batch Web Solr; do
+    if [ "${layer}_IMAGE_ID" != "" ]; then
+      run-playbook "create-AMI" "layer=$layer" & eval "${layer}_PID=$!"
+    fi
+  done
+  for layer in Batch Web Solr; do
+    eval "PID=\$${layer}_PID"
+    if [ "$PID" != "" ]; then
+      wait "$PID"
+    fi
+  done
   run-playbook "AMI-templates.yml" "state=absent"
 }
 


### PR DESCRIPTION
The logic to detect existing images and skip image creation was not actually configuring the autoscaling groups to _use_ the existing image IDs.