### PR TITLE
[QOLDEV-955] update shared QGOV plugin

### DIFF
--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -771,8 +771,7 @@ def lock_account(context):
     for x in range(11):
         context.execute_steps(u"""
             When I attempt to log in with password "incorrect password"
-            Then I should see "Bad username or password or "
-            And I should see "CAPTCHA."
+            Then I should see "Bad username or password."
         """)
 
 

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -22,7 +22,7 @@ extensions:
       description: "CKAN Extension for Queensland Government sites"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qgov.git"
-      version: "7.0.0"
+      version: "7.0.1"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -22,7 +22,7 @@ extensions:
       description: "CKAN Extension for Queensland Government sites"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qgov.git"
-      version: "7.0.0"
+      version: "7.0.1"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"

--- a/vars/shared-Publications.var.yml
+++ b/vars/shared-Publications.var.yml
@@ -14,7 +14,7 @@ extensions:
       description: "CKAN Extension for Queensland Government sites"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-qgov.git"
-      version: "7.0.0"
+      version: "7.0.1"
 
     CKANExtS3Filestore: &CKANExtS3Filestore
       name: "ckanext-s3filestore-{{ Environment }}"


### PR DESCRIPTION
- Handle change of Webassets code structure
- Handle new schema definition for password resets
- Don't override the login failure message if CAPTCHA is not enabled
- Drop Python 2 support
- Handle deprecation of 'webstore_url' field