### PR TITLE
[QOLDEV-1020] update Resource Visibility plugin for CKAN 2.11

### DIFF
--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -158,7 +158,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-resource-visibility.git"
-      version: "2.1.1"
+      version: "2.1.2"
 
     CKANExtOIDC: &CKANExtOIDC
       name: "ckanext-oidc-pkce-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -158,7 +158,7 @@ extensions:
       description: "CKAN Extension for preventing Cross-Site Request Forgery attacks"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-resource-visibility.git"
-      version: "2.1.1"
+      version: "2.1.2"
 
     CKANExtOIDC: &CKANExtOIDC
       name: "ckanext-oidc-pkce-{{ Environment }}"


### PR DESCRIPTION
- Fix 'package_show' parameter to use 'id' rather than the broken fallback 'name_or_id'