### PR TITLE
[QOLDEV-954] update cookbook to prepare for CKAN 2.11

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -40,7 +40,7 @@ common_stack: &common_stack
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
-    CookbookRevision: "{{ CookbookRevision | default('9.0.1') }}"
+    CookbookRevision: "{{ CookbookRevision | default('10.0.0') }}"
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr_url }}"


### PR DESCRIPTION
- drop obsolete Recline-based views
- drop obsolete CSRF filter config
- add batch jobs to refresh reports, Solr index
- ensure plugins have a chance to apply database migrations