### PR TITLE
Temporarily disable updating security groups due to CloudFormation inline template size limit

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -25,7 +25,7 @@ run-playbook () {
 
 run-shared-resource-playbooks () {
   run-playbook "vpc"
-  run-playbook "security_groups"
+  #run-playbook "security_groups"
   run-playbook "CloudFormation" "vars/hosted-zone.var.yml"
   run-playbook "CloudFormation" "vars/database.var.yml"
   run-playbook "CloudFormation" "vars/efs.var.yml"


### PR DESCRIPTION
Template size now exceeds the maximum of 51200 and needs to be split into separate templates. This is a temporary fix to get deployments working.