### PR TITLE
[QOLDEV-1138] add stricter throttling rules to the API

### DIFF
--- a/templates/waf_web_acl.cfn.yml
+++ b/templates/waf_web_acl.cfn.yml
@@ -33,8 +33,30 @@ Resources:
           VisibilityConfig:
             CloudWatchMetricsEnabled: true
             MetricName: "RateLimitRule"
-        - Name: !Sub "${Environment}-${Platform}-XSSRule"
+        - Name: !Sub "${Environment}-${Platform}-APIRateLimitRule"
+          # Throttle API requests more aggressively than general requests
           Priority: 2
+          Action:
+            Block: {}
+          Statement:
+            RateBasedStatement:
+              AggregateKeyType: "IP"
+              EvaluationWindowSec: 60
+              Limit: 60
+              ScopeDownStatement:
+                RegexMatchStatement:
+                  FieldToMatch:
+                    UriPath: {}
+                  RegexString:
+                    /api/
+                  TextTransformations:
+                    - Priority: 0
+                      Type: NONE
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: "APIRateLimitRule"
+        - Name: !Sub "${Environment}-${Platform}-XSSRule"
+          Priority: 3
           Action:
             Block: {}
           Statement:


### PR DESCRIPTION
- Requesting pages and stylesheets is fine so long as it's not overwhelming, but hammering the API can be a sign of attempting to enumerate users or otherwise brute-force something, so put more stringent rate limits on the API.