### PR TITLE
inject XLoader job token into test config

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -37,8 +37,6 @@ commands:
     cmd: |
       ahoy title "Building and starting Docker containers"
       sh bin/docker-compose.sh up -d "$@"
-      echo "Initialising database schema"
-      ahoy cli '"${APP_DIR}"/bin/init.sh'
       echo "Waiting for containers to start listening..."
       for i in `seq 1 60`; do
         if (ahoy cli "timeout 1 bash -c 'cat < /dev/null > /dev/tcp/ckan/5000'"); then
@@ -46,7 +44,7 @@ commands:
           break
         else
           echo "CKAN not yet ready, retrying (attempt $i)..."
-          sleep 1
+          sleep 5
         fi
       done
       if sh bin/docker-compose.sh logs | grep -q "\[Error\]"; then exit 1; fi
@@ -107,7 +105,7 @@ commands:
     cmd: |
       ahoy title "Installing a fresh site"
       ahoy start-ckan-job-workers
-      ahoy cli '"${APP_DIR}"/bin/init.sh && "${APP_DIR}"/bin/create-test-data.sh'
+      ahoy cli '"${APP_DIR}"/bin/create-test-data.sh'
       ahoy stop-ckan-job-workers
 
   clean:

--- a/bin/init-OpenData.sh
+++ b/bin/init-OpenData.sh
@@ -29,3 +29,9 @@ if (ckan_cli datarequests --help); then
         ckan_cli datarequests update_db
     fi
 fi
+
+# Populate the XLoader job token
+ckan_cli user add xloader fullname="Express Loader" email="xloader@localhost" password="Password123!"
+ckan_cli sysadmin add xloader
+API_KEY=$(ckan_cli user token add xloader job_token |tail -1 | tr -d '[:space:]')
+ckan config-tool $CKAN_INI ckanext.xloader.api_token=$API_KEY

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
+. $APP_DIR/bin/init.sh
+
 . "${APP_DIR}"/bin/activate
 if (which ckan > /dev/null); then
     ckan -c ${CKAN_INI} run --disable-reloader --threaded

--- a/test/features/schema_generation.feature
+++ b/test/features/schema_generation.feature
@@ -1,5 +1,6 @@
 @OpenData
 @multi_plugin
+@schema_generation
 Feature: Schema Generation
     Enable worker with `ckan jobs clear && ckan jobs worker`, since these tests rely on background tasks
 


### PR DESCRIPTION
- Adjust setup order so database init happens immediately before launching CKAN instance
- Inject the XLoader job token into config during init