### PR TITLE
[QOLSVC-10616] update Data theme

### DIFF
--- a/.docker/test-OpenData.ini
+++ b/.docker/test-OpenData.ini
@@ -94,7 +94,7 @@ ckan.redis.url = redis://redis:6379
 
 ## Plugins Settings
 ckan.plugins =
-    stats resource_proxy text_view webpage_view image_view
+    stats resource_proxy text_view webpage_view image_view datastore
     data_qld data_qld_google_analytics data_qld_test
     dcat structured_data
     validation
@@ -110,7 +110,7 @@ ckan.plugins =
     archiver
     harvest
     resource_visibility
-    ssm_config datastore
+    ssm_config
     xloader
     oidc_pkce
 

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -14,6 +14,12 @@ Feature: Theme customisations (Publications and OpenData)
         Then I should see "jQuery"
 
     @unauthenticated
+    Scenario: As a member of the public, when I go to api get urls, I can see a valid response
+        Given "Unauthenticated" as the persona
+        When I visit "/api/3/action/package_search?q=a"
+        Then I should see "/api/3/action/help_show?name=package_search", "success": true, "result":"
+
+    @unauthenticated
     Scenario: Lato font is implemented on homepage
         Given "Unauthenticated" as the persona
         When I go to homepage

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -206,7 +206,7 @@ def confirm_dataset_deletion_dialog_if_present(context):
 @when(u'I open the new resource form for dataset "{name}"')
 def go_to_new_resource_form(context, name):
     context.execute_steps(u"""
-         When I go to dataset "{0}"
+        When I go to dataset "{0}"
         And I press "Add new resource"
     """.format(name))
 

--- a/test/fixtures/psv_resource.psv
+++ b/test/fixtures/psv_resource.psv
@@ -1,2 +1,0 @@
-field1|field2
-foo|baz

--- a/vars/shared-CKANTest.var.yml
+++ b/vars/shared-CKANTest.var.yml
@@ -83,7 +83,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.3.7"
+      version: "7.3.8"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"

--- a/vars/shared-OpenData.var.yml
+++ b/vars/shared-OpenData.var.yml
@@ -83,7 +83,7 @@ extensions:
       description: "CKAN Extension for Queensland Government Open Data"
       type: "git"
       url: "https://github.com/qld-gov-au/ckanext-data-qld.git"
-      version: "7.3.7"
+      version: "7.3.8"
 
     CKANExtDataRequests: &CKANExtDataRequests
       name: "ckanext-datarequests-{{ Environment }}"


### PR DESCRIPTION
- Simplify template overrides, including not unnecessarily replacing the datastore plugin
- Sync tests with ckanext-data-qld