### PR TITLE
[QOLDEV-1278] upgrade to gp3 storage

### DIFF
--- a/templates/AMI-Template-Instances.cfn.yml.j2
+++ b/templates/AMI-Template-Instances.cfn.yml.j2
@@ -77,13 +77,13 @@ Resources:
             Encrypted: true
             DeleteOnTermination: true
             VolumeSize: 100
-            VolumeType: "gp2"
+            VolumeType: "gp3"
         - DeviceName: "/dev/sdi"
           Ebs:
             Encrypted: true
             DeleteOnTermination: true
             VolumeSize: !Ref {{ layer }}EC2SecondaryDiskSize
-            VolumeType: "gp2"
+            VolumeType: "gp3"
       IamInstanceProfile:
         Fn::ImportValue:
           Fn::Join:

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -180,13 +180,13 @@ Resources:
               Encrypted: true
               DeleteOnTermination: true
               VolumeSize: 100
-              VolumeType: "gp2"
+              VolumeType: "gp3"
           - DeviceName: "/dev/sdi"
             Ebs:
               Encrypted: true
               DeleteOnTermination: true
               VolumeSize: !Ref {{ layer }}EC2SecondaryDiskSize
-              VolumeType: "gp2"
+              VolumeType: "gp3"
         IamInstanceProfile:
           Name:
             Fn::ImportValue:

--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -133,7 +133,7 @@ Resources:
     Properties:
       MultiAZ: !Ref MultiAZ
       StorageEncrypted: !Ref StorageEncrypted
-      StorageType: gp2
+      StorageType: gp3
       AllocatedStorage: !Ref DBAllocatedStorage
       DBInstanceClass: !Ref DBClass
       DBName: !Ref DBName


### PR DESCRIPTION
- gp3 is cheaper than gp2 and offers better performance on volumes smaller than 1TB, ours are no more than 100GB.