### PR TITLE
[QOLDEV-1278] move database instances to Graviton architecture

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -23,7 +23,30 @@ run-playbook () {
   ansible-playbook -i inventory/hosts "$PLAYBOOK" --extra-vars "@$VARS_FILE" $VARS_FILE_2 --extra-vars "$ANSIBLE_EXTRA_VARS" -vvv
 }
 
+# Switch off ELB health checks while changing core components like the database,
+# which can cause health check errors but the EC2 instances don't need replacement.
+set_health_checks () {
+  CHECK_TYPE=EC2
+  for truthy in `echo "y t true T 1" |xargs echo`; do
+    if [ "$1" = "$truthy" ]; then
+      CHECK_TYPE=ELB
+      break
+    fi
+  done
+
+  for APP_NAME in `echo "OpenData Publications CKANTest"`; do
+    # configure health checks for every app since components are shared,
+    # but skip any app that doesn't exist in this environment,
+    # ie CKANTest only exists up to TRAINING.
+    ASG_NAME="${ENVIRONMENT}-${APP_NAME}-Web-ASG"
+    aws autoscaling describe-auto-scaling-groups --region ap-southeast-2 --auto-scaling-group-names "$ASG_NAME" >/dev/null || continue
+    echo "Setting health check type for $ASG_NAME to ${CHECK_TYPE}..."
+    aws autoscaling update-auto-scaling-group --region ap-southeast-2 --auto-scaling-group-name "$ASG_NAME" --health-check-type "$CHECK_TYPE"
+  done
+}
+
 run-shared-resource-playbooks () {
+  set_health_checks false
   run-playbook "vpc"
   run-playbook "CloudFormation" "vars/security_groups.var.yml"
   run-playbook "CloudFormation" "vars/hosted-zone.var.yml"
@@ -31,6 +54,7 @@ run-shared-resource-playbooks () {
   run-playbook "CloudFormation" "vars/efs.var.yml"
   run-playbook "CloudFormation" "vars/cache.var.yml"
   run-playbook "CloudFormation" "vars/waf_web_acl.var.yml"
+  set_health_checks true
 }
 
 run-deployment () {

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -108,6 +108,7 @@ deploy () {
     if [ "$PARALLEL" = "$truthy" ]; then
       debug "$MESSAGE: Parallel enabled, will deploy to all target instances simultaneously"
       PARALLEL=true
+      break
     fi
   done
 

--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -38,12 +38,12 @@ Parameters:
     Type: Number
   DBClass:
     AllowedValues:
-    - db.t2.medium
     - db.t3.medium
-    - db.t2.large
+    - db.t4g.medium
     - db.t3.large
-    - db.m4.large
+    - db.t4g.large
     - db.m5.large
+    - db.m6g.large
     ConstraintDescription: must select a valid database instance type.
     Description: Database instance class
     Type: String

--- a/vars/database.var.yml
+++ b/vars/database.var.yml
@@ -31,7 +31,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "600"
-      DBClass: db.m5.large
+      DBClass: db.m6g.large
       DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "True"
       PreferredMaintenanceWindow: "sat:17:00-sat:17:30"
@@ -46,7 +46,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: '300'
-      DBClass: db.t3.large
+      DBClass: db.t4g.large
       DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "True"
       Environment: STAGING
@@ -60,7 +60,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "100"
-      DBClass: db.t3.medium
+      DBClass: db.t4g.medium
       DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "False"
       Environment: TRAINING
@@ -75,7 +75,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       DBEngineVersion: 15
       DBAllocatedStorage: "200"
-      DBClass: db.t3.medium
+      DBClass: db.t4g.medium
       DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "False"
       Environment: DEV


### PR DESCRIPTION
- Graviton is cheaper and performance is similar enough for our use case. Architecture difference should be irrelevant for managed RDS.