### PR TITLE
[QOLDEV-1278] migrate EC2 instances to next generation of processors

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -1,3 +1,3 @@
 [local]
-# ami-0059ed5a3aacdfe15: Amazon Linux 2023 AMI 2023.8.20250915.0 x86_64 HVM kernel-6.1
-localhost region=ap-southeast-2 Owner="Development and Delivery" Division="Qld Online" base_ami="ami-0059ed5a3aacdfe15"
+# ami-081c2a1c34031672c: Amazon Linux 2023 AMI 2023.10.20260202.2 arm64 HVM kernel-6.1
+localhost region=ap-southeast-2 Owner="Development and Delivery" Division="Qld Online" base_ami="ami-081c2a1c34031672c"

--- a/templates/AMI-Template-Instances.cfn.yml.j2
+++ b/templates/AMI-Template-Instances.cfn.yml.j2
@@ -92,7 +92,7 @@ Resources:
               - !Ref ApplicationName
               - !Ref {{ layer }}InstanceProfileName
       ImageId: "{{ base_ami }}"
-      InstanceType: "t3a.small"
+      InstanceType: "t4g.small"
       KeyName: !Ref DefaultEC2Key
       NetworkInterfaces:
         - DeviceIndex: 0

--- a/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
+++ b/templates/Datashades-OpsWorks-CKAN-Instances.cfn.yml.j2
@@ -23,23 +23,16 @@ Parameters:
   SolrEC2Size:
     Description: Select EC2 Instance Size for Solr
     Type: String
-    Default: t3.small
+    Default: t4g.small
     AllowedValues:
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
       - t3a.micro
       - t3a.small
       - t3a.medium
       - t3a.large
-      - m3.medium
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m4.10xlarge
-      - m5.12xlarge
+      - t4g.micro
+      - t4g.small
+      - t4g.medium
+      - t4g.large
   SolrEC2SecondaryDiskSize:
     Description: The size (in gigabytes) of the non-root disk to add to Solr instances.
     Type: Number
@@ -61,23 +54,16 @@ Parameters:
   WebEC2Size:
     Description: Select EC2 Instance Size.
     Type: String
-    Default: t3.small
+    Default: t4g.small
     AllowedValues:
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
       - t3a.micro
       - t3a.small
       - t3a.medium
       - t3a.large
-      - m3.medium
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m4.10xlarge
-      - m5.12xlarge
+      - t4g.micro
+      - t4g.small
+      - t4g.medium
+      - t4g.large
   WebEC2SecondaryDiskSize:
     Description: The size (in gigabytes) of the non-root disk to add to web instances.
     Type: Number
@@ -93,24 +79,17 @@ Parameters:
   BatchEC2Size:
     Description: Select EC2 Instance Size for background jobs.
     Type: String
-    Default: t3.small
+    Default: t4g.small
     AllowedValues:
       - none
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
       - t3a.micro
       - t3a.small
       - t3a.medium
       - t3a.large
-      - m3.medium
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m4.10xlarge
-      - m5.12xlarge
+      - t4g.micro
+      - t4g.small
+      - t4g.medium
+      - t4g.large
   BatchEC2SecondaryDiskSize:
     Description: The size (in gigabytes) of the non-root disk to add to batch instances.
     Type: Number

--- a/vars/instances-CKANTest.var.yml
+++ b/vars/instances-CKANTest.var.yml
@@ -45,9 +45,9 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: TRAINING
-      SolrEC2Size: t3a.micro
+      SolrEC2Size: t4g.micro
       SolrEC2Count: 1
-      BatchEC2Size: t3a.micro
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"
@@ -58,10 +58,10 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       Environment: DEV
       WebEC2Count: 1
-      SolrEC2Size: t3a.micro
+      SolrEC2Size: t4g.micro
       SolrEC2Count: 1
-      WebEC2Size: t3a.micro
-      BatchEC2Size: t3a.micro
+      WebEC2Size: t4g.micro
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"

--- a/vars/instances-OpenData.var.yml
+++ b/vars/instances-OpenData.var.yml
@@ -9,8 +9,8 @@ common_stack: &common_stack
   template_parameters: &common_stack_template_parameters
     ApplicationName: "{{ service_name }}"
     ApplicationId: "{{ service_name_lower }}"
-    WebEC2Size: t3a.medium
-    BatchEC2Size: t3a.medium
+    WebEC2Size: t4g.medium
+    BatchEC2Size: t4g.medium
     AppSubnets: "{{ Environment }}CKANAppSubnet"
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
@@ -30,7 +30,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      SolrEC2Size: t3a.medium
+      SolrEC2Size: t4g.medium
       WebEC2Count: 5
     tags:
       <<: *common_stack_tags
@@ -41,7 +41,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      SolrEC2Size: t3a.medium
+      SolrEC2Size: t4g.medium
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"
@@ -51,7 +51,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: TRAINING
-      SolrEC2Size: t3a.small
+      SolrEC2Size: t4g.small
       SolrEC2Count: 1
     tags:
       <<: *common_stack_tags
@@ -63,7 +63,7 @@ cloudformation_stacks:
       <<: *common_stack_template_parameters
       Environment: DEV
       WebEC2Count: 1
-      SolrEC2Size: t3a.small
+      SolrEC2Size: t4g.small
       SolrEC2Count: 1
     tags:
       <<: *common_stack_tags

--- a/vars/instances-Publications.var.yml
+++ b/vars/instances-Publications.var.yml
@@ -8,7 +8,7 @@ common_stack: &common_stack
   template_parameters: &common_stack_template_parameters
     ApplicationName: "{{ service_name }}"
     ApplicationId: "{{ service_name_lower }}"
-    BatchEC2Size: t3.micro
+    BatchEC2Size: t4g.micro
     AppSubnets: "{{ Environment }}CKANAppSubnet"
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
@@ -28,9 +28,9 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: PROD
-      SolrEC2Size: t3a.small
-      WebEC2Size: t3a.small
-      BatchEC2Size: t3a.micro
+      SolrEC2Size: t4g.small
+      WebEC2Size: t4g.small
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "No"
@@ -40,9 +40,9 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: STAGING
-      SolrEC2Size: t3a.small
-      WebEC2Size: t3a.small
-      BatchEC2Size: t3a.micro
+      SolrEC2Size: t4g.small
+      WebEC2Size: t4g.small
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"
@@ -52,10 +52,10 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: TRAINING
-      SolrEC2Size: t3a.small
+      SolrEC2Size: t4g.small
       SolrEC2Count: 1
-      WebEC2Size: t3a.small
-      BatchEC2Size: t3a.micro
+      WebEC2Size: t4g.small
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"
@@ -65,11 +65,11 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       Environment: DEV
-      SolrEC2Size: t3a.micro
+      SolrEC2Size: t4g.micro
       SolrEC2Count: 1
       WebEC2Count: 1
-      WebEC2Size: t3a.micro
-      BatchEC2Size: t3a.micro
+      WebEC2Size: t4g.micro
+      BatchEC2Size: t4g.micro
     tags:
       <<: *common_stack_tags
       PowerManaged: "Yes"


### PR DESCRIPTION
- Graviton is cheaper and has similar performance characteristics for our use case.