### PR TITLE
[QOLCHG-1382] use custom AMI as baseline

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -83,6 +83,7 @@ create-amis () {
       IMAGE_ID=$(aws ec2 describe-images --filters "Name=tag:Environment,Values=$ENVIRONMENT" "Name=tag:Service,Values=$INSTANCE_NAME" "Name=tag:Version,Values=$IMAGE_VERSION" "Name=tag:Layer,Values=$lowercase_layer" --query "Images[].ImageId" --output text |tail -1 |tr -d '[:space:]')
       if [ "$IMAGE_ID" = "" ]; then
         AMI_NEEDED=1
+        echo "No $layer image found, will generate"
       else
         echo "Found existing image(s): $IMAGE_ID"
         aws ssm put-parameter --overwrite --type String --name "/config/CKAN/$ENVIRONMENT/app/$INSTANCE_SHORTNAME/${layer}AmiId" --value "$IMAGE_ID"

--- a/chef-deploy.sh
+++ b/chef-deploy.sh
@@ -21,8 +21,12 @@ RUN_LIST="recipe[$(echo $COMMAND | sed 's/,/],recipe[/g')]"
 
 # Retrieve generated custom JSON
 CHEF_SOURCE=$(cat templates/chef-source.json | tr -d '\n')
-
 REGION_SNIPPET="--region ap-southeast-2"
+CHEF_COMMAND="$(cat <<PARAMETER_STRING
+aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --parameters '{$CHEF_SOURCE,"RunList":[$RUN_LIST],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["None"],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" $REGION_SNIPPET --query "Command.CommandId" --output text
+PARAMETER_STRING
+)"
+
 MESSAGE="[$COMMAND on $SERVICE $ENVIRONMENT $LAYER_NAME]"
 debug "$MESSAGE: commencing..."
 
@@ -150,7 +154,7 @@ deploy () {
     INSTANCE_REFRESH_ID=$(aws autoscaling start-instance-refresh --auto-scaling-group-name $ASG_NAME --preferences '{"MinHealthyPercentage": 50}' --query "InstanceRefreshId" --output text)
     wait_for_instance_refresh $INSTANCE_REFRESH_ID
   elif [ "$PARALLEL" = "true" ]; then
-    DEPLOYMENT_ID=$(aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --instance-ids $INSTANCE_IDS --parameters '{'"$CHEF_SOURCE"',"RunList":["'"$RUN_LIST"'"],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["18"],"ChefClientArguments":[""],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" $REGION_SNIPPET --query "Command.CommandId" --output text)
+    DEPLOYMENT_ID=$($CHEF_COMMAND --instance-ids $INSTANCE_IDS)
     wait_for_deployment $DEPLOYMENT_ID || return 1
   else
     for instance in $INSTANCE_IDS; do
@@ -173,7 +177,7 @@ deploy () {
         OUTPUT=$(aws autoscaling enter-standby --auto-scaling-group-name "$ASG_NAME" $DECREMENT_BEHAVIOUR --instance-ids $instance --query "Activities[].Description" --output text)
         debug "$OUTPUT"
       fi
-      DEPLOYMENT_ID=$(aws ssm send-command --document-name "AWS-ApplyChefRecipes" --document-version "\$DEFAULT" --instance-ids $instance --parameters '{'"$CHEF_SOURCE"',"RunList":["'"$RUN_LIST"'"],"JsonAttributesSources":[""],"JsonAttributesContent":[""],"ChefClientVersion":["18"],"ChefClientArguments":[""],"WhyRun":["False"],"ComplianceSeverity":["None"],"ComplianceType":["Custom:Chef"],"ComplianceReportBucket":[""]}' --timeout-seconds 3600 --max-concurrency "50" --max-errors "0" --output-s3-bucket-name "osssio-ckan-web-logs" --output-s3-key-prefix "run_command" --region ap-southeast-2 --query "Command.CommandId" --output text)
+      DEPLOYMENT_ID=$($CHEF_COMMAND --instance-ids $instance)
       DEPLOYMENT_SUCCESS=0
       wait_for_deployment $DEPLOYMENT_ID || DEPLOYMENT_SUCCESS=$?
       if [ "$IN_ASG" = "true" ]; then

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -1,3 +1,3 @@
 [local]
-# ami-081c2a1c34031672c: Amazon Linux 2023 AMI 2023.10.20260202.2 arm64 HVM kernel-6.1
-localhost region=ap-southeast-2 Owner="Development and Delivery" Division="Qld Online" base_ami="ami-081c2a1c34031672c"
+# ami-068ee98b7c68b44bf: Amazon Linux 2023 AMI 2023.10.20260202.2 arm64 HVM kernel-6.1 (built on ami-081c2a1c34031672c) with Chef 18
+localhost region=ap-southeast-2 Owner="Development and Delivery" Division="Qld Online" base_ami="ami-068ee98b7c68b44bf"


### PR DESCRIPTION
- We have manually generated an AMI with Chef client preinstalled, since installing on the fly depends on the availability of the mirror
- Also refactor assembly of Chef command