### PR TITLE
[QOLSVC-13800] fix production RDS instance size

### DIFF
--- a/templates/database.cfn.yml
+++ b/templates/database.cfn.yml
@@ -44,6 +44,7 @@ Parameters:
     - db.t4g.large
     - db.m5.large
     - db.m6g.large
+    - db.m6g.xlarge
     ConstraintDescription: must select a valid database instance type.
     Description: Database instance class
     Type: String

--- a/vars/database.var.yml
+++ b/vars/database.var.yml
@@ -31,7 +31,7 @@ cloudformation_stacks:
     template_parameters:
       <<: *common_stack_template_parameters
       DBAllocatedStorage: "600"
-      DBClass: db.m6g.large
+      DBClass: db.m6g.xlarge
       DBMaxParallelWorkersPerGather: 0 #increase if have more than 4 cpu core
       StorageEncrypted: "True"
       PreferredMaintenanceWindow: "sat:17:00-sat:17:30"


### PR DESCRIPTION
- RDS had been manually changed to m5.xlarge, but this was not reflected in CloudFormation, so our move to m6g changed it instead to m6g.large. Performance post-deployment indicates that xlarge is still necessary. (Disk credits consumed at unsustainable rate, intermittent HTTP 502 to Pingdom)