### PR TITLE
Develop to master - update cookbook to use Python 3.11

### DIFF
--- a/vars/CKAN-Stack.var.yml
+++ b/vars/CKAN-Stack.var.yml
@@ -37,7 +37,7 @@ common_stack: &common_stack
     EnableDataStore: "{{ enable_datastore | default('no') }}"
     SSMKey: "{{ SSMKey | default('') }}"
     DefaultEC2Key: "{{ lookup('aws_ssm', '/config/CKAN/ec2KeyPair', region=region) }}"
-    CookbookRevision: "{{ CookbookRevision | default('10.4.2') }}"
+    CookbookRevision: "{{ CookbookRevision | default('10.5.0') }}"
     LogBucketName: "{{ lookup('aws_ssm', '/config/CKAN/s3LogsBucket', region=region) }}"
     AttachmentsBucketName: "{{ lookup('aws_ssm', '/config/CKAN/' + Environment + '/app/' + service_name_lower + '/s3AttachmentBucket', region=region) }}" #/config/CKAN/PROD/app/opendata/s3AttachmentBucket
     SolrSource: "{{ solr_url }}"


### PR DESCRIPTION
Upcoming CKAN 2.11.5 will require Python 3.10+