### PR TITLE
QOLDEV-2122 checks and balances to ensure we have latest image, and warn us in higher env's

### DIFF
--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -87,7 +87,7 @@ create-baseline-ami () {
     echo ""
     echo "Please update the comment and VANILLA_IMAGE_ID to:"
     echo "  # $LATEST_VANILLA_DESCRIPTION ($LATEST_IMAGE_NAME) - $LATEST_VANILLA_CREATION_DATE"
-    echo "  VANILLA_IMAGE_ID=\"$LATEST_VANILLA_IMAGE\" "
+    echo "  VANILLA_IMAGE_ID=\"$LATEST_VANILLA_IMAGE\""
     echo ""
     if [[ "$ENVIRONMENT" == "DEV" || "$ENVIRONMENT" == "TEST" ]]; then
       echo "In Lower environment: $ENVIRONMENT. "

--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -69,11 +69,30 @@ run-deployment () {
 
 create-baseline-ami () {
   # https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes.html
-  # Amazon Linux 2023 AMI 2023.12.20260724.0 arm64 HVM kernel-6.1  (al2023-ami-2023.12.20260724.0-kernel-6.1-arm64)
-  VANILLA_IMAGE_ID="ami-0263e54f0becbac65"
-  LATEST_VANILLA_IMAGE=$(aws ec2 describe-images --filters "Name=name,Values=al2023-ami-2023*-arm64" --query "Images[].[Name, ImageId]" --output text |sort |tail -1 |cut -f 2)
+  # Amazon Linux 2023 AMI 2023.12.20260727.0 arm64 HVM kernel-6.1 (al2023-ami-2023.12.20260727.0-kernel-6.1-arm64) - 2026-07-25T00:03:18.000Z
+  VANILLA_IMAGE_ID="ami-0f707e657d81da75d"
+  read -r \
+    LATEST_IMAGE_NAME \
+    LATEST_VANILLA_IMAGE \
+    LATEST_VANILLA_CREATION_DATE \
+    LATEST_VANILLA_DESCRIPTION < <(
+      aws ec2 describe-images \
+        --filters "Name=name,Values=al2023-ami-2023*-arm64" \
+        --query 'sort_by(Images,&CreationDate)[-1].[Name,ImageId,CreationDate,Description]' \
+        --output text
+  )
   if [ "$VANILLA_IMAGE_ID" != "$LATEST_VANILLA_IMAGE" ]; then
     echo "Using $VANILLA_IMAGE_ID; however, a newer operating system image exists, $LATEST_VANILLA_IMAGE"
+    echo ""
+    echo "Please update the comment and VANILLA_IMAGE_ID to:"
+    echo "  # $LATEST_VANILLA_DESCRIPTION ($LATEST_IMAGE_NAME) - $LATEST_VANILLA_CREATION_DATE"
+    echo "  VANILLA_IMAGE_ID=\"$LATEST_VANILLA_IMAGE\" "
+    echo ""
+    if [[ "$ENVIRONMENT" == "DEV" || "$ENVIRONMENT" == "TEST" ]]; then
+      echo "In Lower environment: $ENVIRONMENT. "
+      echo "Stopping build."
+      exit 1
+    fi
   fi
   BASELINE_IMAGE_ID=$(aws ssm get-parameter --name "/config/CKAN/$ENVIRONMENT/common/BaselineAmiId" --query "Parameter.Value" --output text)
   if [ "$BASELINE_IMAGE_ID" != "" ]; then

--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -77,6 +77,7 @@ create-baseline-ami () {
     LATEST_VANILLA_CREATION_DATE \
     LATEST_VANILLA_DESCRIPTION < <(
       aws ec2 describe-images \
+        --owners amazon \
         --filters "Name=name,Values=al2023-ami-2023*-arm64" \
         --query 'sort_by(Images,&CreationDate)[-1].[Name,ImageId,CreationDate,Description]' \
         --output text

--- a/build-CKAN.sh
+++ b/build-CKAN.sh
@@ -89,7 +89,7 @@ create-baseline-ami () {
     echo "  # $LATEST_VANILLA_DESCRIPTION ($LATEST_IMAGE_NAME) - $LATEST_VANILLA_CREATION_DATE"
     echo "  VANILLA_IMAGE_ID=\"$LATEST_VANILLA_IMAGE\""
     echo ""
-    if [[ "$ENVIRONMENT" == "DEV" || "$ENVIRONMENT" == "TEST" ]]; then
+    if [ "$ENVIRONMENT" = "DEV" ]; then
       echo "In Lower environment: $ENVIRONMENT. "
       echo "Stopping build."
       exit 1


### PR DESCRIPTION
Extract out more variables from ami lookup.
Create nice comment with the ami code to ease in creation.

Only block the build in DEV or TEST (when we do make one)


stretch goal for future when moved to github actions, 'generate' a branch/pr with new comment via workflow (outside of deployment)